### PR TITLE
pin black version

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -46,6 +46,7 @@ jobs:
         pip install -r requirements.txt
         # Optional Dependency for HDF Checkpointing
         pip install tables
+        pip install flake8-pytest-importorskip
         python setup.py install
         python setup.py build_ext --inplace
         python -m pip list

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     - name: Update Black
       if: ${{ matrix.python-version == 3.7 }}
       run: |
-        pip install --upgrade black
+        pip install black==21.12b0
 
     - name: Lint and Format Check with Flake8 and Black
       if: ${{ matrix.python-version == 3.7 }}

--- a/hatchet/readers/spotdb_reader.py
+++ b/hatchet/readers/spotdb_reader.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from numpy import string_
 import pandas as pd
 
 import hatchet.graphframe

--- a/hatchet/tests/spotdb_test.py
+++ b/hatchet/tests/spotdb_test.py
@@ -8,12 +8,6 @@ import pytest
 from hatchet import GraphFrame
 from hatchet.readers.spotdb_reader import SpotDatasetReader, SpotDBReader
 
-spotdb_avail = True
-try:
-    import spotdb
-except ImportError:
-    spotdb_avail = False
-
 
 def test_spot_dataset_reader():
     """Sanity-check the Spot dataset reader"""
@@ -39,9 +33,9 @@ def test_spot_dataset_reader():
     assert gf.default_metric == "M Alias (inc)"
 
 
-@pytest.mark.skipif(not spotdb_avail, reason="spotdb module not available")
 def test_spotdb_reader(spotdb_data):
     """Sanity check for the SpotDB reader"""
+    spotdb = pytest.importorskip("spotdb", reason="spotdb module not available")
 
     db = spotdb_data
 
@@ -60,9 +54,9 @@ def test_spotdb_reader(spotdb_data):
     assert "launchdate" in gfs[0].metadata.keys()
 
 
-@pytest.mark.skipif(not spotdb_avail, reason="spotdb module not available")
 def test_from_spotdb(spotdb_data):
     """Sanity check for GraphFrame.from_spotdb"""
+    spotdb = pytest.importorskip("spotdb", reason="spotdb module not available")
 
     db = spotdb_data
     runs = db.get_all_run_ids()


### PR DESCRIPTION
Pin black version to maintain python 2.7 as a version that should be supported by Black's output. Newer versions removed support for python 2.7.