### PR TITLE
Preserve existing inc_metrics in update_inclusive_columns

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -684,7 +684,7 @@ class GraphFrame:
             return
 
         new_inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
-        self.inc_metrics.extend(new_inc_metrics)
+        self.inc_metrics = list(set(self.inc_metrics + new_inc_metrics))
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 
     def show_metric_columns(self):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -683,9 +683,12 @@ class GraphFrame:
         if not self.exc_metrics:
             return
 
-        new_inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
-        self.inc_metrics = list(set(self.inc_metrics + new_inc_metrics))
+        # TODO When Python 2.7 support is dropped, change this line to the more idiomatic:
+        # old_inc_metrics = self.inc_metrics.copy()
+        old_inc_metrics = list(self.inc_metrics)
+        self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
+        self.inc_metrics = list(set(self.inc_metrics + old_inc_metrics))
 
     def show_metric_columns(self):
         """Returns a list of dataframe column labels."""

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -683,7 +683,8 @@ class GraphFrame:
         if not self.exc_metrics:
             return
 
-        self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
+        new_inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
+        self.inc_metrics.extend(new_inc_metrics)
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 
     def show_metric_columns(self):

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -348,6 +348,176 @@ def mock_graph_literal():
 
 
 @pytest.fixture
+def mock_graph_literal_inc_time_as_foo():
+    """Same as mock_graph_literal, but the "time (inc)"
+    metric is renamed to "foo"
+    """
+    graph_dict = [
+        {
+            "frame": {"name": "foo", "type": "function"},
+            "metrics": {"foo": 135.0, "time": 0.0},
+            "children": [
+                {
+                    "frame": {"name": "bar"},
+                    "metrics": {"foo": 20.0, "time": 5.0},
+                    "children": [
+                        {
+                            "frame": {"name": "baz", "type": "function"},
+                            "metrics": {"foo": 5.0, "time": 5.0},
+                        },
+                        {
+                            "frame": {"name": "grault"},
+                            "metrics": {"foo": 10.0, "time": 10.0},
+                        },
+                    ],
+                },
+                {
+                    "frame": {"name": "qux", "type": "function"},
+                    "metrics": {"foo": 60.0, "time": 0.0},
+                    "children": [
+                        {
+                            "frame": {"name": "quux"},
+                            "metrics": {"foo": 60.0, "time": 5.0},
+                            "children": [
+                                {
+                                    "frame": {"name": "corge", "type": "function"},
+                                    "metrics": {"foo": 55.0, "time": 10.0},
+                                    "children": [
+                                        {
+                                            "frame": {"name": "bar"},
+                                            "metrics": {
+                                                "foo": 20.0,
+                                                "time": 5.0,
+                                            },
+                                            "children": [
+                                                {
+                                                    "frame": {
+                                                        "name": "baz",
+                                                        "type": "function",
+                                                    },
+                                                    "metrics": {
+                                                        "foo": 5.0,
+                                                        "time": 5.0,
+                                                    },
+                                                },
+                                                {
+                                                    "frame": {"name": "grault"},
+                                                    "metrics": {
+                                                        "foo": 10.0,
+                                                        "time": 10.0,
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        {
+                                            "frame": {"name": "grault"},
+                                            "metrics": {
+                                                "foo": 10.0,
+                                                "time": 10.0,
+                                            },
+                                        },
+                                        {
+                                            "frame": {
+                                                "name": "garply",
+                                                "type": "function",
+                                            },
+                                            "metrics": {
+                                                "foo": 15.0,
+                                                "time": 15.0,
+                                            },
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "frame": {"name": "waldo", "type": "function"},
+                    "metrics": {"foo": 55.0, "time": 0.0},
+                    "children": [
+                        {
+                            "frame": {"name": "fred", "type": "function"},
+                            "metrics": {"foo": 40.0, "time": 5.0},
+                            "children": [
+                                {
+                                    "frame": {"name": "plugh", "type": "function"},
+                                    "metrics": {"foo": 5.0, "time": 5.0},
+                                },
+                                {
+                                    "frame": {"name": "xyzzy", "type": "function"},
+                                    "metrics": {"foo": 30.0, "time": 5.0},
+                                    "children": [
+                                        {
+                                            "frame": {
+                                                "name": "thud",
+                                                "type": "function",
+                                            },
+                                            "metrics": {
+                                                "foo": 25.0,
+                                                "time": 5.0,
+                                            },
+                                            "children": [
+                                                {
+                                                    "frame": {
+                                                        "name": "baz",
+                                                        "type": "function",
+                                                    },
+                                                    "metrics": {
+                                                        "foo": 5.0,
+                                                        "time": 5.0,
+                                                    },
+                                                },
+                                                {
+                                                    "frame": {
+                                                        "name": "garply",
+                                                        "type": "function",
+                                                    },
+                                                    "metrics": {
+                                                        "foo": 15.0,
+                                                        "time": 15.0,
+                                                    },
+                                                },
+                                            ],
+                                        }
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            "frame": {"name": "garply", "type": "function"},
+                            "metrics": {"foo": 15.0, "time": 15.0},
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "frame": {"name": "waldo", "type": "function"},
+            "metrics": {"foo": 30.0, "time": 10.0},
+            "children": [
+                {
+                    "frame": {"name": "bar"},
+                    "metrics": {"foo": 20.0, "time": 5.0},
+                    "children": [
+                        {
+                            "frame": {"name": "baz", "type": "function"},
+                            "metrics": {"foo": 5.0, "time": 5.0},
+                        },
+                        {
+                            "frame": {"name": "grault"},
+                            "metrics": {"foo": 10.0, "time": 10.0},
+                        },
+                    ],
+                }
+            ],
+        },
+    ]
+
+    return graph_dict
+
+
+@pytest.fixture
 def mock_dag_literal1():
     """Creates a mock DAG."""
     dag_ldict = [

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -348,46 +348,46 @@ def mock_graph_literal():
 
 
 @pytest.fixture
-def mock_graph_literal_inc_time_as_foo():
-    """Same as mock_graph_literal, but the "time (inc)"
-    metric is renamed to "foo"
+def mock_graph_literal_time_as_line():
+    """Same as mock_graph_literal, but the "time"
+    metric is renamed to "line"
     """
     graph_dict = [
         {
             "frame": {"name": "foo", "type": "function"},
-            "metrics": {"foo": 135.0, "time": 0.0},
+            "metrics": {"time (inc)": 135.0, "line": 0.0},
             "children": [
                 {
                     "frame": {"name": "bar"},
-                    "metrics": {"foo": 20.0, "time": 5.0},
+                    "metrics": {"time (inc)": 20.0, "line": 5.0},
                     "children": [
                         {
                             "frame": {"name": "baz", "type": "function"},
-                            "metrics": {"foo": 5.0, "time": 5.0},
+                            "metrics": {"time (inc)": 5.0, "line": 5.0},
                         },
                         {
                             "frame": {"name": "grault"},
-                            "metrics": {"foo": 10.0, "time": 10.0},
+                            "metrics": {"time (inc)": 10.0, "line": 10.0},
                         },
                     ],
                 },
                 {
                     "frame": {"name": "qux", "type": "function"},
-                    "metrics": {"foo": 60.0, "time": 0.0},
+                    "metrics": {"time (inc)": 60.0, "line": 0.0},
                     "children": [
                         {
                             "frame": {"name": "quux"},
-                            "metrics": {"foo": 60.0, "time": 5.0},
+                            "metrics": {"time (inc)": 60.0, "line": 5.0},
                             "children": [
                                 {
                                     "frame": {"name": "corge", "type": "function"},
-                                    "metrics": {"foo": 55.0, "time": 10.0},
+                                    "metrics": {"time (inc)": 55.0, "line": 10.0},
                                     "children": [
                                         {
                                             "frame": {"name": "bar"},
                                             "metrics": {
-                                                "foo": 20.0,
-                                                "time": 5.0,
+                                                "time (inc)": 20.0,
+                                                "line": 5.0,
                                             },
                                             "children": [
                                                 {
@@ -396,15 +396,15 @@ def mock_graph_literal_inc_time_as_foo():
                                                         "type": "function",
                                                     },
                                                     "metrics": {
-                                                        "foo": 5.0,
-                                                        "time": 5.0,
+                                                        "time (inc)": 5.0,
+                                                        "line": 5.0,
                                                     },
                                                 },
                                                 {
                                                     "frame": {"name": "grault"},
                                                     "metrics": {
-                                                        "foo": 10.0,
-                                                        "time": 10.0,
+                                                        "time (inc)": 10.0,
+                                                        "line": 10.0,
                                                     },
                                                 },
                                             ],
@@ -412,8 +412,8 @@ def mock_graph_literal_inc_time_as_foo():
                                         {
                                             "frame": {"name": "grault"},
                                             "metrics": {
-                                                "foo": 10.0,
-                                                "time": 10.0,
+                                                "time (inc)": 10.0,
+                                                "line": 10.0,
                                             },
                                         },
                                         {
@@ -422,8 +422,8 @@ def mock_graph_literal_inc_time_as_foo():
                                                 "type": "function",
                                             },
                                             "metrics": {
-                                                "foo": 15.0,
-                                                "time": 15.0,
+                                                "time (inc)": 15.0,
+                                                "line": 15.0,
                                             },
                                         },
                                     ],
@@ -434,19 +434,19 @@ def mock_graph_literal_inc_time_as_foo():
                 },
                 {
                     "frame": {"name": "waldo", "type": "function"},
-                    "metrics": {"foo": 55.0, "time": 0.0},
+                    "metrics": {"time (inc)": 55.0, "line": 0.0},
                     "children": [
                         {
                             "frame": {"name": "fred", "type": "function"},
-                            "metrics": {"foo": 40.0, "time": 5.0},
+                            "metrics": {"time (inc)": 40.0, "line": 5.0},
                             "children": [
                                 {
                                     "frame": {"name": "plugh", "type": "function"},
-                                    "metrics": {"foo": 5.0, "time": 5.0},
+                                    "metrics": {"time (inc)": 5.0, "line": 5.0},
                                 },
                                 {
                                     "frame": {"name": "xyzzy", "type": "function"},
-                                    "metrics": {"foo": 30.0, "time": 5.0},
+                                    "metrics": {"time (inc)": 30.0, "line": 5.0},
                                     "children": [
                                         {
                                             "frame": {
@@ -454,8 +454,8 @@ def mock_graph_literal_inc_time_as_foo():
                                                 "type": "function",
                                             },
                                             "metrics": {
-                                                "foo": 25.0,
-                                                "time": 5.0,
+                                                "time (inc)": 25.0,
+                                                "line": 5.0,
                                             },
                                             "children": [
                                                 {
@@ -464,8 +464,8 @@ def mock_graph_literal_inc_time_as_foo():
                                                         "type": "function",
                                                     },
                                                     "metrics": {
-                                                        "foo": 5.0,
-                                                        "time": 5.0,
+                                                        "time (inc)": 5.0,
+                                                        "line": 5.0,
                                                     },
                                                 },
                                                 {
@@ -474,8 +474,8 @@ def mock_graph_literal_inc_time_as_foo():
                                                         "type": "function",
                                                     },
                                                     "metrics": {
-                                                        "foo": 15.0,
-                                                        "time": 15.0,
+                                                        "time (inc)": 15.0,
+                                                        "line": 15.0,
                                                     },
                                                 },
                                             ],
@@ -486,7 +486,7 @@ def mock_graph_literal_inc_time_as_foo():
                         },
                         {
                             "frame": {"name": "garply", "type": "function"},
-                            "metrics": {"foo": 15.0, "time": 15.0},
+                            "metrics": {"time (inc)": 15.0, "line": 15.0},
                         },
                     ],
                 },
@@ -494,19 +494,19 @@ def mock_graph_literal_inc_time_as_foo():
         },
         {
             "frame": {"name": "waldo", "type": "function"},
-            "metrics": {"foo": 30.0, "time": 10.0},
+            "metrics": {"time (inc)": 30.0, "line": 10.0},
             "children": [
                 {
                     "frame": {"name": "bar"},
-                    "metrics": {"foo": 20.0, "time": 5.0},
+                    "metrics": {"time (inc)": 20.0, "line": 5.0},
                     "children": [
                         {
                             "frame": {"name": "baz", "type": "function"},
-                            "metrics": {"foo": 5.0, "time": 5.0},
+                            "metrics": {"time (inc)": 5.0, "line": 5.0},
                         },
                         {
                             "frame": {"name": "grault"},
-                            "metrics": {"foo": 10.0, "time": 10.0},
+                            "metrics": {"time (inc)": 10.0, "line": 10.0},
                         },
                     ],
                 }

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1176,3 +1176,18 @@ def test_hdf_load_store(mock_graph_literal):
 
     if os.path.exists("test_gframe.hdf"):
         os.remove("test_gframe.hdf")
+
+
+def test_preserve_inc_metrics(mock_graph_literal_inc_time_as_foo):
+    gf = GraphFrame.from_literal(mock_graph_literal_inc_time_as_foo)
+    if "foo" in gf.exc_metrics:
+        gf.exc_metrics.remove("foo")
+    if "foo" not in gf.inc_metrics:
+        gf.inc_metrics.append("foo")
+
+    assert sorted(gf.exc_metrics) == ["time"]
+    assert sorted(gf.inc_metrics) == ["foo"]
+
+    gf.update_inclusive_columns()
+    assert sorted(gf.inc_metrics) == sorted(["time (inc)", "foo"])
+    assert gf.dataframe["time (inc)"].equals(gf.dataframe["foo"])

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1178,16 +1178,16 @@ def test_hdf_load_store(mock_graph_literal):
         os.remove("test_gframe.hdf")
 
 
-def test_preserve_inc_metrics(mock_graph_literal_inc_time_as_foo):
-    gf = GraphFrame.from_literal(mock_graph_literal_inc_time_as_foo)
-    if "foo" in gf.exc_metrics:
-        gf.exc_metrics.remove("foo")
-    if "foo" not in gf.inc_metrics:
-        gf.inc_metrics.append("foo")
+def test_preserve_inc_metrics(mock_graph_literal_time_as_line):
+    gf = GraphFrame.from_literal(mock_graph_literal_time_as_line)
+    if "line" in gf.inc_metrics:
+        gf.inc_metrics.remove("line")
+    if "line" not in gf.exc_metrics:
+        gf.exc_metrics.append("line")
 
-    assert sorted(gf.exc_metrics) == ["time"]
-    assert sorted(gf.inc_metrics) == ["foo"]
+    assert sorted(gf.exc_metrics) == ["line"]
+    assert sorted(gf.inc_metrics) == ["time (inc)"]
 
     gf.update_inclusive_columns()
-    assert sorted(gf.inc_metrics) == sorted(["time (inc)", "foo"])
-    assert gf.dataframe["time (inc)"].equals(gf.dataframe["foo"])
+    assert sorted(gf.inc_metrics) == sorted(["time (inc)", "line (inc)"])
+    assert gf.dataframe["time (inc)"].equals(gf.dataframe["line (inc)"])

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1180,10 +1180,6 @@ def test_hdf_load_store(mock_graph_literal):
 
 def test_preserve_inc_metrics(mock_graph_literal_time_as_line):
     gf = GraphFrame.from_literal(mock_graph_literal_time_as_line)
-    if "line" in gf.inc_metrics:
-        gf.inc_metrics.remove("line")
-    if "line" not in gf.exc_metrics:
-        gf.exc_metrics.append("line")
 
     assert sorted(gf.exc_metrics) == ["line"]
     assert sorted(gf.inc_metrics) == ["time (inc)"]


### PR DESCRIPTION
This is a small PR to fix a bug in `GraphFrame.update_inclusive_columns` that causes existing values in `GraphFrame.inc_columns` to be dropped.

As an example, consider a `GraphFrame` with the following metrics:
* `exc_metrics`: `["time"]`
* `inc_metrics`: `["foo"]`

Currently, after calling `update_inclusive_columns`, `inc_metrics` will no longer contain `"foo"`. Instead, `inc_metrics` will simply be `["time (inc)"]`.

This PR will extend `inc_metrics` instead of overriding. So, in the above example, `inc_metrics` will now be `["foo", "time (inc)"]`.