### PR TITLE
Calculates exclusive metrics from corresponding inclusive metrics

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -741,7 +741,15 @@ class GraphFrame:
         # TODO When Python 2.7 support is dropped, change this line to the more idiomatic:
         # old_inc_metrics = self.inc_metrics.copy()
         old_inc_metrics = list(self.inc_metrics)
-        self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
+        # TODO Change this logic when inc_metrics and exc_metrics are changed
+        new_inc_metrics = []
+        for exc in self.exc_metrics:
+            if exc.endswith("(exc)"):
+                new_inc_metrics.append(exc[:-len("(exc)")].strip())
+            else:
+                new_inc_metrics.append("%s (inc)" % exc)
+        self.inc_metrics = new_inc_metrics
+
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
         self.inc_metrics = list(set(self.inc_metrics + old_inc_metrics))
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -710,8 +710,16 @@ class GraphFrame:
                 generation_pairs.append((inc + " (exc)", inc))
         for exc, inc in generation_pairs:
             if isinstance(self.dataframe.index, pd.MultiIndex):
-                # See subtree_sum for indexing help
-                pass
+                new_data = {}
+                for node in self.graph.traverse():
+                    for non_node_idx in self.dataframe.loc[(node)].index.unique():
+                        assert isinstance(non_node_idx, tuple) or isinstance(non_node_idx, list), "MultiIndex iteration is not producing the expected type"
+                        full_idx = (node, *non_node_idx)
+                        inc_sum = 0
+                        for child in node.children:
+                            inc_sum += self.dataframe[(child, *non_node_idx), inc]
+                        new_data[full_idx] = self.dataframe[full_idx, inc] - inc_sum
+                self.dataframe[exc] = pd.Series(data=new_data)
             else:
                 new_data = {n: -1 for n in self.dataframe.index.values}
                 for node in self.graph.traverse():

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -696,46 +696,86 @@ class GraphFrame:
                 )
 
     def generate_exclusive_columns(self):
+        """Generates exclusive metrics from available inclusive metrics.
+
+        Currently, this function determines which metrics to generate by looking for one of two things:
+
+        1. An inclusive metric ending in "(inc)" that does not have an exclusive metric with the same name (minus "(inc)")
+        2. An inclusive metric not ending in "(inc)"
+
+        The metrics that are generated will have one of two name formats:
+
+        1. If the corresponding inclusive metric's name ends in "(inc)", the exclusive metric will have the same
+           name, minus "(inc)"
+        2. If the corresponding inclusive metric's name does not end in "(inc)", the exclusive metric will have the same
+           name as the inclusive metric, followed by a "(exc)" suffix
+        """
         # TODO Change how exclusive-inclusive pairs are determined when inc_metrics and exc_metrics are changed
+        # Iterate over inclusive metrics and collect tuples of (new exclusive metrics name, inclusive metric name)
         generation_pairs = []
         for inc in self.inc_metrics:
+            # If the metric isn't numeric, it is really categorical. This means the inclusive/exclusive thing doesn't really apply.
             if not pd.api.types.is_numeric_dtype(self.dataframe[inc]):
                 continue
             # Assume that metrics ending in "(inc)" are generated
             if inc.endswith("(inc)"):
                 possible_exc = inc[: -len("(inc)")].strip()
+                # If a metric with the same name as the inclusive metrics minus the "(inc)" does not exist in exc_metrics,
+                # assume that there is not a corresponding exclusive metric. So, add this new exclusive metric to the generation list.
                 if possible_exc not in self.exc_metrics:
                     generation_pairs.append((possible_exc, inc))
+            # If there is an inclusive metric without the "(inc)" suffix,
+            # assume that there is no corresponding exclusive metric. So, add this new exclusive metrics (with the "(exc)"
+            # suffix) to the generation list.
             else:
                 generation_pairs.append((inc + " (exc)", inc))
+        # Consider each new exclusive metric and its corresponding inclusive metric
         for exc, inc in generation_pairs:
+            # Process of obtaining inclusive data for a node differs if the DataFrame has an Index vs a MultiIndex
             if isinstance(self.dataframe.index, pd.MultiIndex):
                 new_data = {}
+                # Traverse every node in the Graph
                 for node in self.graph.traverse():
+                    # Consider each unique portion of the MultiIndex corresponding to the current node
                     for non_node_idx in self.dataframe.loc[(node)].index.unique():
+                        # Quick sanity-check assertion to make sure our data is in the correct format
                         assert isinstance(non_node_idx, tuple) or isinstance(
                             non_node_idx, list
                         ), "MultiIndex iteration is not producing the expected type"
+                        # Build the full index
                         # TODO: Replace the full_idx assignment with the following when 2.7 support
                         # is dropped:
                         # full_idx = (node, *non_node_idx)
                         full_idx = (node) + tuple(non_node_idx)
+                        # Iterate over the children of the current node and add up
+                        # their values for the inclusive metric
                         inc_sum = 0
                         for child in node.children:
                             # TODO: See note about full_idx above
                             child_idx = (child) + tuple(non_node_idx)
                             inc_sum += self.dataframe.loc[child_idx, inc]
+                        # Subtract the current node's inclusive metric from the previously calculated sum to
+                        # get the exclusive metric value for the node
                         new_data[full_idx] = self.dataframe.loc[full_idx, inc] - inc_sum
+                # Add the exclusive metric as a new column in the DataFrame
                 self.dataframe[exc] = pd.Series(data=new_data)
             else:
+                # Create a basic Node-metric dict for the new exclusive metric
                 new_data = {n: -1 for n in self.dataframe.index.values}
+                # Traverse the graph
                 for node in self.graph.traverse():
+                    # Sum up the inclusive metric values of the current node's children
                     inc_sum = 0
                     for child in node.children:
                         inc_sum += self.dataframe.loc[child, inc]
+                    # Subtract the current node's inclusive metric from the previously calculated sum to
+                    # get the exclusive metric value for the node
                     new_data[node] = self.dataframe.loc[node, inc] - inc_sum
+                # Add the exclusive metric as a new column in the DataFrame
                 self.dataframe[exc] = pd.Series(data=new_data)
+        # Add the newly created metrics to self.exc_metrics
         self.exc_metrics.extend([metric_tuple[0] for metric_tuple in generation_pairs])
+        self.exc_metrics = list(set(self.exc_metrics))
 
     def update_inclusive_columns(self):
         """Update inclusive columns (typically after operations that rewire the

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -728,6 +728,7 @@ class GraphFrame:
                         inc_sum += self.dataframe[child, inc]
                     new_data[node] = self.dataframe[node, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
+        self.exc_metrics.extend([metric_tuple[0] for metric_tuple in generation_pairs])
 
     def update_inclusive_columns(self):
         """Update inclusive columns (typically after operations that rewire the

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -703,7 +703,7 @@ class GraphFrame:
                 continue
             # Assume that metrics ending in "(inc)" are generated
             if inc.endswith("(inc)"):
-                possible_exc = inc[:-len("(inc)")].strip()
+                possible_exc = inc[: -len("(inc)")].strip()
                 if possible_exc not in self.exc_metrics:
                     generation_pairs.append((possible_exc, inc))
             else:
@@ -713,11 +713,18 @@ class GraphFrame:
                 new_data = {}
                 for node in self.graph.traverse():
                     for non_node_idx in self.dataframe.loc[(node)].index.unique():
-                        assert isinstance(non_node_idx, tuple) or isinstance(non_node_idx, list), "MultiIndex iteration is not producing the expected type"
-                        full_idx = (node, *non_node_idx)
+                        assert isinstance(non_node_idx, tuple) or isinstance(
+                            non_node_idx, list
+                        ), "MultiIndex iteration is not producing the expected type"
+                        # TODO: Replace the full_idx assignment with the following when 2.7 support
+                        # is dropped:
+                        # full_idx = (node, *non_node_idx)
+                        full_idx = (node) + tuple(non_node_idx)
                         inc_sum = 0
                         for child in node.children:
-                            inc_sum += self.dataframe.loc[(child, *non_node_idx), inc]
+                            # TODO: See note about full_idx above
+                            child_idx = (child) + tuple(non_node_idx)
+                            inc_sum += self.dataframe.loc[child_idx, inc]
                         new_data[full_idx] = self.dataframe.loc[full_idx, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
             else:
@@ -745,7 +752,7 @@ class GraphFrame:
         new_inc_metrics = []
         for exc in self.exc_metrics:
             if exc.endswith("(exc)"):
-                new_inc_metrics.append(exc[:-len("(exc)")].strip())
+                new_inc_metrics.append(exc[: -len("(exc)")].strip())
             else:
                 new_inc_metrics.append("%s (inc)" % exc)
         self.inc_metrics = new_inc_metrics

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -695,6 +695,32 @@ class GraphFrame:
                     function(self.dataframe.loc[(subgraph_nodes), columns])
                 )
 
+    def generate_exclusive_columns(self):
+        # TODO Change how exclusive-inclusive pairs are determined when inc_metrics and exc_metrics are changed
+        generation_pairs = []
+        for inc in self.inc_metrics:
+            if not pd.api.types.is_numeric_dtype(self.dataframe[inc]):
+                continue
+            # Assume that metrics ending in "(inc)" are generated
+            if inc.endswith("(inc)"):
+                possible_exc = inc[:-len("(inc)")].strip()
+                if possible_exc not in self.exc_metrics:
+                    generation_pairs.append((possible_exc, inc))
+            else:
+                generation_pairs.append((inc + " (exc)", inc))
+        for exc, inc in generation_pairs:
+            if isinstance(self.dataframe.index, pd.MultiIndex):
+                # See subtree_sum for indexing help
+                pass
+            else:
+                new_data = {n: -1 for n in self.dataframe.index.values}
+                for node in self.graph.traverse():
+                    inc_sum = 0
+                    for child in node.children:
+                        inc_sum += self.dataframe[child, inc]
+                    new_data[node] = self.dataframe[node, inc] - inc_sum
+                self.dataframe[exc] = pd.Series(data=new_data)
+
     def update_inclusive_columns(self):
         """Update inclusive columns (typically after operations that rewire the
         graph.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -717,16 +717,16 @@ class GraphFrame:
                         full_idx = (node, *non_node_idx)
                         inc_sum = 0
                         for child in node.children:
-                            inc_sum += self.dataframe[(child, *non_node_idx), inc]
-                        new_data[full_idx] = self.dataframe[full_idx, inc] - inc_sum
+                            inc_sum += self.dataframe.loc[(child, *non_node_idx), inc]
+                        new_data[full_idx] = self.dataframe.loc[full_idx, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
             else:
                 new_data = {n: -1 for n in self.dataframe.index.values}
                 for node in self.graph.traverse():
                     inc_sum = 0
                     for child in node.children:
-                        inc_sum += self.dataframe[child, inc]
-                    new_data[node] = self.dataframe[node, inc] - inc_sum
+                        inc_sum += self.dataframe.loc[child, inc]
+                    new_data[node] = self.dataframe.loc[node, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
         self.exc_metrics.extend([metric_tuple[0] for metric_tuple in generation_pairs])
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1198,3 +1198,49 @@ def test_preserve_inc_metrics(mock_graph_literal_time_as_line):
     gf.update_inclusive_columns()
     assert sorted(gf.inc_metrics) == sorted(["time (inc)", "line (inc)"])
     assert gf.dataframe["time (inc)"].equals(gf.dataframe["line (inc)"])
+
+
+def test_generate_exclusive_columns_w_index(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+
+    assert isinstance(gf.dataframe.index, pd.Index)
+
+    gf_time_inc = gf.copy()
+    gf_time_inc.dataframe.drop(columns=["time"], inplace=True)
+    gf_time_inc.exc_metrics.remove("time")
+    gf_time_inc.generate_exclusive_columns()
+    assert "time" in gf_time_inc.exc_metrics
+    assert gf.dataframe["time"].equals(gf_time_inc.dataframe["time"])
+
+    gf_time = gf.copy()
+    gf_time.dataframe.drop(columns=["time"], inplace=True)
+    gf_time.exc_metrics.remove("time")
+    gf_time.dataframe.rename(columns={"time (inc)": "time"}, inplace=True)
+    gf_time.inc_metrics.remove("time (inc)")
+    gf_time.inc_metrics.append("time")
+    gf_time.generate_exclusive_columns()
+    assert "time (exc)" in gf_time.exc_metrics
+    assert gf.dataframe["time"].equals(gf_time.dataframe["time (exc)"])
+
+
+def test_generate_exclusive_columns_w_multi_index(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+
+    assert isinstance(gf.dataframe.index, pd.MultiIndex)
+
+    gf_time_inc = gf.copy()
+    gf_time_inc.dataframe.drop(columns=["time"], inplace=True)
+    gf_time_inc.exc_metrics.remove("time")
+    gf_time_inc.generate_exclusive_columns()
+    assert "time" in gf_time_inc.exc_metrics
+    assert gf.dataframe["time"].equals(gf_time_inc.dataframe["time"])
+
+    gf_time = gf.copy()
+    gf_time.dataframe.drop(columns=["time"], inplace=True)
+    gf_time.exc_metrics.remove("time")
+    gf_time.dataframe.rename(columns={"time (inc)": "time"}, inplace=True)
+    gf_time.inc_metrics.remove("time (inc)")
+    gf_time.inc_metrics.append("time")
+    gf_time.generate_exclusive_columns()
+    assert "time (exc)" in gf_time.exc_metrics
+    assert gf.dataframe["time"].equals(gf_time.dataframe["time (exc)"])


### PR DESCRIPTION
This PR adds the `generate_exclusive_columns` function to calculate exclusive metrics from inclusive metrics. It does this by calculating the sum of the inclusive metric for each node's children and then subtracting that from the node's inclusive metric. It will only attempt to calculate exclusive metrics in certain situations, namely:
* The inclusive metric name ends in "(inc)", but there is not an exclusive metric with the same name, minus the "(inc)"
* There is an inclusive metric without the "(inc)" suffix

This might not be ideal. However, Hatchet currently provides no mechanism internally for explicitly correlating exclusive and inclusive metrics. So, until such functionality is added, this PR must use some solution based on metric names to determine what to calculate. When the internal mechanism for recording inclusive and exclusive metrics is updated, this function will be updated to use that new feature.

This PR builds off of #18, so it will be marked as a Draft until that PR is merged.