### PR TITLE
Add global config

### DIFF
--- a/hatchet/__init__.py
+++ b/hatchet/__init__.py
@@ -8,4 +8,4 @@
 
 from .graphframe import GraphFrame
 from .query import QueryMatcher
-from .util.rcmanager import RcParams 
+from .util.rcmanager import RcParams

--- a/hatchet/__init__.py
+++ b/hatchet/__init__.py
@@ -8,3 +8,4 @@
 
 from .graphframe import GraphFrame
 from .query import QueryMatcher
+from .util.rcmanager import RcParams 

--- a/hatchet/tests/rctest.py
+++ b/hatchet/tests/rctest.py
@@ -1,0 +1,35 @@
+from hatchet.util.rcmanager import RcManager, _resolve_conf_file, _read_config_from_file
+
+
+def test_creation():
+    file = _resolve_conf_file()
+    config = _read_config_from_file(file)
+    RC = RcManager(config)
+
+    assert RC is not None
+
+
+def test_global_binding():
+    import hatchet as ht
+
+    assert hasattr(ht, "RcParams")
+
+
+def test_change_value():
+    import hatchet as ht
+
+    assert "logging" in ht.RcParams
+
+    ht.RcParams["logging"] = True
+    assert ht.RcParams["logging"] is True
+
+    from hatchet.util.rcmanager import RcParams
+
+    assert RcParams["logging"] is True
+
+    ht.RcParams["logging"] = False
+    assert ht.RcParams["logging"] is False
+
+    from hatchet.util.rcmanager import RcParams
+
+    assert RcParams["logging"] is False

--- a/hatchet/tests/rctest.py
+++ b/hatchet/tests/rctest.py
@@ -84,3 +84,42 @@ def test_validator():
         assert False
     except TypeError:
         assert True
+
+    #Testing valid inputs
+    # Goes through to true assertion if
+    # validation works
+    try:
+        V.validate("bad_bool", True)
+        assert True
+    except TypeError:
+        assert False
+
+    try:
+        V.validate("bad_string", "string")
+        assert True
+    except TypeError:
+        assert False
+
+    try:
+        V.validate("bad_int", 1)
+        assert True
+    except TypeError:
+        assert False
+
+    try:
+        V.validate("bad_float", 1.2387)
+        assert True
+    except TypeError:
+        assert False
+
+    try:
+        V.validate("bad_list", [])
+        assert True
+    except TypeError:
+        assert False
+
+    try:
+        V.validate("bad_dict", {})
+        assert True
+    except TypeError:
+        assert False

--- a/hatchet/tests/rctest.py
+++ b/hatchet/tests/rctest.py
@@ -1,4 +1,9 @@
-from hatchet.util.rcmanager import RcManager, _resolve_conf_file, _read_config_from_file
+from hatchet.util.rcmanager import (
+    RcManager,
+    ConfigValidator,
+    _resolve_conf_file,
+    _read_config_from_file,
+)
 
 
 def test_creation():
@@ -28,3 +33,54 @@ def test_change_value():
     ht.RcParams["logging"] = False
     assert ht.RcParams["logging"] is False
     assert RcParams["logging"] is False
+
+
+def test_validator():
+    V = ConfigValidator()
+
+    # Add validators for keys where we can input
+    # bad values
+    V._validations["bad_bool"] = V.bool_validator
+    V._validations["bad_string"] = V.str_validator
+    V._validations["bad_int"] = V.int_validator
+    V._validations["bad_float"] = V.float_validator
+    V._validations["bad_list"] = V.list_validator
+    V._validations["bad_dict"] = V.dict_validator
+
+    # Test passes if exception is thrown
+    # Else: test fails
+    try:
+        V.validate("bad_bool", "True")
+        assert False
+    except TypeError:
+        assert True
+
+    try:
+        V.validate("bad_string", True)
+        assert False
+    except TypeError:
+        assert True
+
+    try:
+        V.validate("bad_int", "123")
+        assert False
+    except TypeError:
+        assert True
+
+    try:
+        V.validate("bad_float", "1.2387")
+        assert False
+    except TypeError:
+        assert True
+
+    try:
+        V.validate("bad_list", {})
+        assert False
+    except TypeError:
+        assert True
+
+    try:
+        V.validate("bad_dict", [])
+        assert False
+    except TypeError:
+        assert True

--- a/hatchet/tests/rctest.py
+++ b/hatchet/tests/rctest.py
@@ -17,19 +17,14 @@ def test_global_binding():
 
 def test_change_value():
     import hatchet as ht
+    from hatchet.util.rcmanager import RcParams
 
     assert "logging" in ht.RcParams
 
     ht.RcParams["logging"] = True
     assert ht.RcParams["logging"] is True
-
-    from hatchet.util.rcmanager import RcParams
-
     assert RcParams["logging"] is True
 
     ht.RcParams["logging"] = False
     assert ht.RcParams["logging"] is False
-
-    from hatchet.util.rcmanager import RcParams
-
     assert RcParams["logging"] is False

--- a/hatchet/tests/rctest.py
+++ b/hatchet/tests/rctest.py
@@ -85,7 +85,7 @@ def test_validator():
     except TypeError:
         assert True
 
-    #Testing valid inputs
+    # Testing valid inputs
     # Goes through to true assertion if
     # validation works
     try:

--- a/hatchet/util/rcmanager.py
+++ b/hatchet/util/rcmanager.py
@@ -6,6 +6,87 @@ import os.path as path
 import yaml
 
 
+class ConfigValidator:
+    def __init__(self):
+        self._validations = {}
+        self._set_validators_to_configs()
+
+    def bool_validator(self, key, value):
+        if not isinstance(value, bool):
+            raise TypeError(
+                'Error loading configuration: Configuration "{}" must be of type bool'.format(
+                    key
+                )
+            )
+        else:
+            return value
+
+    def str_validator(self, key, value):
+        if not isinstance(value, str):
+            raise TypeError(
+                'Error loading configuration: Configuration "{}" must be of type string'.format(
+                    key
+                )
+            )
+        else:
+            return value
+
+    def int_validator(self, key, value):
+        if not isinstance(value, int):
+            raise TypeError(
+                'Error loading configuration: Configuration "{}" must be of type int'.format(
+                    key
+                )
+            )
+        else:
+            return value
+
+    def float_validator(self, key, value):
+        if not isinstance(value, float):
+            raise TypeError(
+                'Error loading configuration: Configuration "{}" must be of type float'.format(
+                    key
+                )
+            )
+        else:
+            return value
+
+    def list_validator(self, key, value):
+        if not isinstance(value, list):
+            raise TypeError(
+                'Error loading configuration: Configuration "{}" must be of type list'.format(
+                    key
+                )
+            )
+        else:
+            return value
+
+    def dict_validator(self, key, value):
+        if not isinstance(value, dict):
+            raise TypeError(
+                'Error loading configuration: Configuration "{}" must be of type dict'.format(
+                    key
+                )
+            )
+        else:
+            return value
+
+    def validate(self, key, value):
+        try:
+            return self._validations[key](key, value)
+        except TypeError as e:
+            raise e
+        except KeyError:
+            pass
+
+    def _set_validators_to_configs(self):
+        # real configurations
+        self._validations["logging"] = self.bool_validator
+        self._validations["log_directory"] = self.str_validator
+        self._validations["highlight_name"] = self.bool_validator
+        self._validations["invert_colormap"] = self.bool_validator
+
+
 class RcManager(MutableMapping, dict):
     """
     A runtime configurations class; modeled after the RcParams class in matplotlib.
@@ -14,13 +95,18 @@ class RcManager(MutableMapping, dict):
     """
 
     def __init__(self, *args, **kwargs):
+        self._validator = ConfigValidator()
         self.update(*args, **kwargs)
 
     def __setitem__(self, key, val):
         """
-        We can put validation of configs here.
+        Function loads valid configurations and prints errors for invalid configs.
         """
-        return dict.__setitem__(self, key, val)
+        try:
+            self._validator.validate(key, val)
+            return dict.__setitem__(self, key, val)
+        except TypeError as e:
+            print(e)
 
     def __getitem__(self, key):
         return dict.__getitem__(self, key)

--- a/hatchet/util/rcmanager.py
+++ b/hatchet/util/rcmanager.py
@@ -1,3 +1,8 @@
+# Copyright 2021 The University of Arizona and other Hatchet Project
+# Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
 try:
     from collections.abc import MutableMapping
 except ImportError:
@@ -129,16 +134,16 @@ def _resolve_conf_file():
     """
     Determines which configuration file to load.
     Uses the precendence order:
-        1. $HOME/.config/hatchet/hatchetrc.yaml
+        1. $HOME/.hatchet/hatchetrc.yaml
         2. $HATCHET_BASE_DIR/hatchetrc.yaml
     """
     home = path.expanduser("~")
-    conf_dir = path.join(home, ".config", "hatchet", "hatchetrc.yaml")
+    conf_dir = path.join(home, ".hatchet", "hatchetrc.yaml")
     if path.exists(conf_dir):
         return conf_dir
     else:
-        my_path = path.abspath(path.dirname(path.abspath(__file__)))
-        rel_path = path.join(my_path, "..", "..", "hatchetrc.yaml")
+        hatchet_path = path.abspath(path.dirname(path.abspath(__file__)))
+        rel_path = path.join(hatchet_path, "..", "..", "hatchetrc.yaml")
         return rel_path
 
 

--- a/hatchet/util/rcmanager.py
+++ b/hatchet/util/rcmanager.py
@@ -5,40 +5,41 @@ except ImportError:
 import os.path as path
 import yaml
 
+
 class RcManager(MutableMapping, dict):
-    '''
-        A runtime configurations class; modeled after the RcParams class in matplotlib. 
-        The benifit of this class over a dictonary is validation of set item and formatting
-        of output.
-    '''
+    """
+    A runtime configurations class; modeled after the RcParams class in matplotlib.
+    The benifit of this class over a dictonary is validation of set item and formatting
+    of output.
+    """
 
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)
 
     def __setitem__(self, key, val):
-        '''
-            We can put validation of configs here.
-        '''
+        """
+        We can put validation of configs here.
+        """
         return dict.__setitem__(self, key, val)
-    
+
     def __getitem__(self, key):
         return dict.__getitem__(self, key)
-    
+
     def __iter__(self):
         for kv in sorted(dict.__iter__(self)):
             yield kv
 
     def __str__(self):
-        return '\n'.join(map('{0[0]}: {0[1]}'.format, sorted(self.items())))
+        return "\n".join(map("{0[0]}: {0[1]}".format, sorted(self.items())))
 
 
 def _resolve_conf_file():
-    '''
-        Determines which configuration file to load.
-        Uses the precendence order:
-            1. $HOME/.config/hatchet/hatchetrc.yaml
-            2. $HATCHET_BASE_DIR/hatchetrc.yaml
-    '''
+    """
+    Determines which configuration file to load.
+    Uses the precendence order:
+        1. $HOME/.config/hatchet/hatchetrc.yaml
+        2. $HATCHET_BASE_DIR/hatchetrc.yaml
+    """
     home = path.expanduser("~")
     conf_dir = path.join(home, ".config", "hatchet", "hatchetrc.yaml")
     if path.exists(conf_dir):
@@ -48,15 +49,16 @@ def _resolve_conf_file():
         rel_path = path.join(my_path, "..", "..", "hatchetrc.yaml")
         return rel_path
 
+
 def _read_config_from_file(filepath):
     configs = {}
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         configs = yaml.load(f, yaml.FullLoader)
     return configs
+
 
 filepath = _resolve_conf_file()
 configs = _read_config_from_file(filepath)
 
 # Global instance of configurations
 RcParams = RcManager(configs)
-

--- a/hatchet/util/rcmanager.py
+++ b/hatchet/util/rcmanager.py
@@ -117,7 +117,7 @@ class RcManager(MutableMapping):
 
     def __str__(self):
         return "\n".join(map("{0[0]}: {0[1]}".format, sorted(self.items())))
-    
+
     def __len__(self):
         return len(self._data)
 

--- a/hatchet/util/rcmanager.py
+++ b/hatchet/util/rcmanager.py
@@ -1,0 +1,62 @@
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+import os.path as path
+import yaml
+
+class RcManager(MutableMapping, dict):
+    '''
+        A runtime configurations class; modeled after the RcParams class in matplotlib. 
+        The benifit of this class over a dictonary is validation of set item and formatting
+        of output.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+
+    def __setitem__(self, key, val):
+        '''
+            We can put validation of configs here.
+        '''
+        return dict.__setitem__(self, key, val)
+    
+    def __getitem__(self, key):
+        return dict.__getitem__(self, key)
+    
+    def __iter__(self):
+        for kv in sorted(dict.__iter__(self)):
+            yield kv
+
+    def __str__(self):
+        return '\n'.join(map('{0[0]}: {0[1]}'.format, sorted(self.items())))
+
+
+def _resolve_conf_file():
+    '''
+        Determines which configuration file to load.
+        Uses the precendence order:
+            1. $HOME/.config/hatchet/hatchetrc.yaml
+            2. $HATCHET_BASE_DIR/hatchetrc.yaml
+    '''
+    home = path.expanduser("~")
+    conf_dir = path.join(home, ".config", "hatchet", "hatchetrc.yaml")
+    if path.exists(conf_dir):
+        return conf_dir
+    else:
+        my_path = path.abspath(path.dirname(__file__))
+        rel_path = path.join(my_path, "..", "..", "hatchetrc.yaml")
+        return rel_path
+
+def _read_config_from_file(filepath):
+    configs = {}
+    with open(filepath, 'r') as f:
+        configs = yaml.load(f, yaml.FullLoader)
+    return configs
+
+filepath = _resolve_conf_file()
+configs = _read_config_from_file(filepath)
+
+# Global instance of configurations
+RcParams = RcManager(configs)
+

--- a/hatchet/util/rcmanager.py
+++ b/hatchet/util/rcmanager.py
@@ -77,12 +77,7 @@ class ConfigValidator:
             return value
 
     def validate(self, key, value):
-        try:
-            return self._validations[key](key, value)
-        except TypeError as e:
-            raise e
-        except KeyError as e:
-            raise e
+        return self._validations[key](key, value)
 
     def _set_validators_to_configs(self):
         self._validations["logging"] = self.bool_validator

--- a/hatchetrc.yaml
+++ b/hatchetrc.yaml
@@ -1,0 +1,12 @@
+##############################################
+##                                          ##
+##  Global configuration file for hatchet.  ##
+##                                          ##
+##############################################
+
+##
+## Logging configuration
+## 
+
+logging: True
+log-directory: "."

--- a/hatchetrc.yaml
+++ b/hatchetrc.yaml
@@ -4,12 +4,18 @@
 ##                                          ##
 ##############################################
 
+## If you would like to customize these global configurations
+## please copy it to the following directory:
+## $HOME/.config/hatchet/
+##
+## The configurations in this file will take precedence
+
 ##
 ## Logging configuration
 ## 
 
 logging: False
-log-directory: "/usr/WS2/asde/hatchet-logs/"
+log_directory: "~"
 
 ##
 ## Tree Output Configuration

--- a/hatchetrc.yaml
+++ b/hatchetrc.yaml
@@ -5,10 +5,15 @@
 ##############################################
 
 ## If you would like to customize these global configurations
-## please copy it to the following directory:
-## $HOME/.config/hatchet/
+## please copy it to the following directory and edit there:
+## $HOME/.hatchet/
 ##
-## The configurations in this file will take precedence
+## This configurations file is considered in the following order of precedence:
+##      1. $HOME/.hatchet/hatchetrc.yaml (optional)
+##      2. $HATCHET_BASE_DIR/hatchetrc.yaml
+##
+## If no file can be found at $HOME/.hatchet then configurations are drawn from
+## the hatchetrc.yaml file at the root of hatchet's installation location
 
 ##
 ## Logging configuration

--- a/hatchetrc.yaml
+++ b/hatchetrc.yaml
@@ -8,5 +8,12 @@
 ## Logging configuration
 ## 
 
-logging: True
-log-directory: "."
+logging: False
+log-directory: "/usr/WS2/asde/hatchet-logs/"
+
+##
+## Tree Output Configuration
+##
+
+highlight_name: False
+invert_colormap: False


### PR DESCRIPTION
Added a global configuration manager.

Features added:

1. A configuration manager class
    a. Basically a dictionary we can validate input on and format output
2. A validation class which performs basic type validation but can be extended to support arbitrary validation
    a. This class does require maintenance.  When we add a new configuration we need to assign a validation function to the configuration key.
3. A configuration file: `hatchetrc.yaml` in the base directory
    a. This is loaded by default when users do not have their own `hatchetrc.yaml` file in directory `$HOME/.config/hatchet/`
    b. This is a .yaml file and accordingly should conform to the YAML syntax and requirements; here is a tutorial with an overview of such syntax: https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/
4. A global variable at hatchet root level scope: `RcParams` pointing to an instance of this class, it can be used in the following way:
```
import hatchet as ht
ht.RcParams["invert_colormap"] = True
```