### PR TITLE
Enable the construction of compound queries from a single mid-level query

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -15,7 +15,7 @@ import multiprocess as mp
 from .node import Node
 from .graph import Graph
 from .frame import Frame
-from .query import AbstractQuery, QueryMatcher, CypherQuery
+from .query import AbstractQuery, QueryMatcher, parse_cypher_query
 from .external.console import ConsoleRenderer
 from .util.dot import trees_to_dot
 from .util.deprecated import deprecated_params
@@ -432,7 +432,7 @@ class GraphFrame:
             if isinstance(filter_obj, list):
                 query = QueryMatcher(filter_obj)
             elif isinstance(filter_obj, str):
-                query = CypherQuery(filter_obj)
+                query = parse_cypher_query(filter_obj)
             query_matches = query.apply(self)
             # match_set = list(set().union(*query_matches))
             # filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(match_set)]

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -1262,14 +1262,14 @@ def parse_cypher_query(query_str):
 
     # Find the number of curly brace-delimited regions in the query
     query_str = query_str.strip()
-    curly_brace_elems = re.findall("\{(.*?)\}", query_str)
+    curly_brace_elems = re.findall(r"\{(.*?)\}", query_str)
     num_curly_brace_elems = len(curly_brace_elems)
     # If there are no curly brace-delimited regions, just pass the query
     # off to the CypherQuery constructor
     if num_curly_brace_elems == 0:
         return CypherQuery(query_str)
     # Create an iterator over the curly brace-delimited regions
-    curly_brace_iter = re.finditer("\{(.*?)\}", query_str)
+    curly_brace_iter = re.finditer(r"\{(.*?)\}", query_str)
     # Will store curly brace-delimited regions in the WHERE clause
     condition_list = None
     # Will store curly brace-delimited regions that contain entire
@@ -1299,7 +1299,7 @@ def parse_cypher_query(query_str):
         # WHERE clause, first, check if the region is within another
         # curly brace delimited region. If it is, do nothing (it will
         # be handled later). Otherwise, add the region to "condition_list"
-        elif re.match("[a-zA-Z0-9_]+\..*", substr) is not None:
+        elif re.match(r"[a-zA-Z0-9_]+\..*", substr) is not None:
             is_encapsulated_region = False
             if query_idxes is not None:
                 for s, e in query_idxes:
@@ -1344,7 +1344,7 @@ def parse_cypher_query(query_str):
                 "Incompatible number of curly brace elements and compound operators"
             )
         # Get the MATCH clause that will be shared across the subqueries
-        match_comp_obj = re.search("MATCH\s+(?P<match_field>.*)\s+WHERE", query_str)
+        match_comp_obj = re.search(r"MATCH\s+(?P<match_field>.*)\s+WHERE", query_str)
         match_comp = match_comp_obj.group("match_field")
         # Iterate over the compound operators
         full_query = None
@@ -1363,11 +1363,11 @@ def parse_cypher_query(query_str):
             # Add the next query to the full query using the compound operator
             # currently being considered
             if op == "AND":
-                full_query = full_query & query2
+                full_query = full_query & next_query
             elif op == "OR":
-                full_query = full_query | query2
+                full_query = full_query | next_query
             else:
-                full_query = full_query ^ query2
+                full_query = full_query ^ next_query
         return full_query
     # This branch is for the full query version
     else:
@@ -1390,11 +1390,11 @@ def parse_cypher_query(query_str):
             # Add the next query to the full query using the compound operator
             # currently being considered
             if op == "AND":
-                full_query = full_query & query2
+                full_query = full_query & next_query
             elif op == "OR":
-                full_query = full_query | query2
+                full_query = full_query | next_query
             else:
-                full_query = full_query ^ query2
+                full_query = full_query ^ next_query
         return full_query
 
 

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -1283,7 +1283,7 @@ def parse_cypher_query(query_str):
     compound_ops = []
     for i, match in enumerate(curly_brace_iter):
         # Get the substring within curly braces
-        substr = query_str[match.start() : match.end()]
+        substr = query_str[match.start() + 1 : match.end() - 1]
         substr = substr.strip()
         # If an entire query (MATCH + WHERE) is within curly braces,
         # add the query to "query_list", and add the indexes corresponding

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -1248,21 +1248,46 @@ class CypherQuery(QueryMatcher):
 
 
 def parse_cypher_query(query_str):
+    """Parse all types of mid-level queries, including multi-queries that leverage
+    the curly brace delimiters.
+
+    Arguments:
+        query_str (str): the mid-level query to be parsed
+
+    Returns:
+        (AbstractQuery): A Hatchet query object representing the mid-level query
+    """
     # TODO Check if there's a way to prevent curly braces in a string
     #      from being captured
+
+    # Find the number of curly brace-delimited regions in the query
     query_str = query_str.strip()
     curly_brace_elems = re.findall("\{(.*?)\}", query_str)
     num_curly_brace_elems = len(curly_brace_elems)
+    # If there are no curly brace-delimited regions, just pass the query
+    # off to the CypherQuery constructor
     if num_curly_brace_elems == 0:
         return CypherQuery(query_str)
+    # Create an iterator over the curly brace-delimited regions
     curly_brace_iter = re.finditer("\{(.*?)\}", query_str)
+    # Will store curly brace-delimited regions in the WHERE clause
     condition_list = None
+    # Will store curly brace-delimited regions that contain entire
+    # mid-level queries (MATCH clause and WHERE clause)
     query_list = None
+    # If entire queries are in brace-delimited regions, store the indexes
+    # of the regions here so we don't consider brace-delimited regions
+    # within the already-captured region.
     query_idxes = None
+    # Store which compound queries to apply to the curly brace-delimited regions
     compound_ops = []
     for i, match in enumerate(curly_brace_iter):
-        substr = query_str[match.start():match.end()]
+        # Get the substring within curly braces
+        substr = query_str[match.start() : match.end()]
         substr = substr.strip()
+        # If an entire query (MATCH + WHERE) is within curly braces,
+        # add the query to "query_list", and add the indexes corresponding
+        # to the query to "query_idxes"
         if substr.startswith("MATCH"):
             if query_list is None:
                 query_list = []
@@ -1270,6 +1295,10 @@ def parse_cypher_query(query_str):
                 query_idxes = []
             query_list.append(substr)
             query_idxes.append((match.start(), match.end()))
+        # If the curly brace-delimited region contains only parts of a
+        # WHERE clause, first, check if the region is within another
+        # curly brace delimited region. If it is, do nothing (it will
+        # be handled later). Otherwise, add the region to "condition_list"
         elif re.match("[a-zA-Z0-9_]+\..*", substr) is not None:
             is_encapsulated_region = False
             if query_idxes is not None:
@@ -1282,10 +1311,14 @@ def parse_cypher_query(query_str):
             if condition_list is None:
                 condition_list = []
             condition_list.append(substr)
+        # If the curly brace-delimited region is neither a whole query
+        # or part of a WHERE clause, raise an error
         else:
             raise ValueError("Invalid grouping (with curly braces) within the query")
-        if i+1 >= num_curly_brace_elems:
-            rest_substr = query_str[match.end():]
+        # If there is a compound operator directly after the curly brace-delimited region,
+        # capture the type of operator, and store the type in "compound_ops"
+        if i + 1 < num_curly_brace_elems:
+            rest_substr = query_str[match.end() :]
             rest_substr = rest_substr.strip()
             if rest_substr.startswith("AND"):
                 compound_ops.append("AND")
@@ -1295,20 +1328,40 @@ def parse_cypher_query(query_str):
                 compound_ops.append("XOR")
             else:
                 raise ValueError("Invalid compound operator type found!")
+    # Each call to this function should only consider one of the full query or
+    # WHERE clause versions at a time. If both types were captured, raise an error
+    # because some type of internal logic issue occured.
     if condition_list is not None and query_list is not None:
-        raise ValueError("Curly braces must be around either a full mid-level query or a set of conditions in a single mid-level query")
+        raise ValueError(
+            "Curly braces must be around either a full mid-level query or a set of conditions in a single mid-level query"
+        )
+    # This branch is for the WHERE clause version
     if condition_list is not None:
+        # Make sure you correctly gathered curly brace-delimited regions and
+        # compound operators
         if len(condition_list) != len(compound_ops) + 1:
-            raise ValueError("Incompatible number of curly brace elements and compound operators")
+            raise ValueError(
+                "Incompatible number of curly brace elements and compound operators"
+            )
+        # Get the MATCH clause that will be shared across the subqueries
         match_comp_obj = re.search("MATCH\s+(?P<match_field>.*)\s+WHERE", query_str)
         match_comp = match_comp_obj.group("match_field")
+        # Iterate over the compound operators
         full_query = None
         for i, op in enumerate(compound_ops):
+            # If in the first iteration, set the initial query as a CypherQuery where
+            # the MATCH clause is the shared match clause and the WHERE clause is the
+            # first curly brace-delimited region
             if i == 0:
                 query1 = "MATCH {} WHERE {}".format(match_comp, condition_list[i])
                 full_query = CypherQuery(query1)
-            next_query = "MATCH {} WHERE {}".format(match_comp, condition_list[i+1])
+            # Get the next query as a CypherQuery where
+            # the MATCH clause is the shared match clause and the WHERE clause is the
+            # next curly brace-delimited region
+            next_query = "MATCH {} WHERE {}".format(match_comp, condition_list[i + 1])
             next_query = CypherQuery(next_query)
+            # Add the next query to the full query using the compound operator
+            # currently being considered
             if op == "AND":
                 full_query = full_query & query2
             elif op == "OR":
@@ -1316,14 +1369,26 @@ def parse_cypher_query(query_str):
             else:
                 full_query = full_query ^ query2
         return full_query
+    # This branch is for the full query version
     else:
+        # Make sure you correctly gathered curly brace-delimited regions and
+        # compound operators
         if len(query_list) != len(compound_ops) + 1:
-            raise ValueError("Incompatible number of curly brace elements and compound operators")
+            raise ValueError(
+                "Incompatible number of curly brace elements and compound operators"
+            )
+        # Iterate over the compound operators
         full_query = None
         for i, op in enumerate(compound_ops):
+            # If in the first iteration, set the initial query as the result
+            # of recursively calling this function on the first curly brace-delimited region
             if i == 0:
                 full_query = parse_cypher_query(query_list[i])
-            next_query = parse_cypher_query(query_list[i+1])
+            # Get the next query by recursively calling this function
+            # on the next curly brace-delimited region
+            next_query = parse_cypher_query(query_list[i + 1])
+            # Add the next query to the full query using the compound operator
+            # currently being considered
             if op == "AND":
                 full_query = full_query & query2
             elif op == "OR":

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -1267,6 +1267,8 @@ def parse_cypher_query(query_str):
     # If there are no curly brace-delimited regions, just pass the query
     # off to the CypherQuery constructor
     if num_curly_brace_elems == 0:
+        if sys.version_info[0] == 2:
+            query_str = query_str.decode("utf-8")
         return CypherQuery(query_str)
     # Create an iterator over the curly brace-delimited regions
     curly_brace_iter = re.finditer(r"\{(.*?)\}", query_str)
@@ -1354,11 +1356,15 @@ def parse_cypher_query(query_str):
             # first curly brace-delimited region
             if i == 0:
                 query1 = "MATCH {} WHERE {}".format(match_comp, condition_list[i])
+                if sys.version_info[0] == 2:
+                    query1 = query1.decode("utf-8")
                 full_query = CypherQuery(query1)
             # Get the next query as a CypherQuery where
             # the MATCH clause is the shared match clause and the WHERE clause is the
             # next curly brace-delimited region
             next_query = "MATCH {} WHERE {}".format(match_comp, condition_list[i + 1])
+            if sys.version_info[0] == 2:
+                next_query = next_query.decode("utf-8")
             next_query = CypherQuery(next_query)
             # Add the next query to the full query using the compound operator
             # currently being considered

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -350,20 +350,6 @@ def test_apply(mock_graph_literal):
         root.children[1].children[0],
         root.children[1].children[0].children[0],
         root.children[1].children[0].children[0].children[1],
-        # Old-style return value of apply
-        # [
-        #     root,
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[1],
-        # ],
-        # [
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[1],
-        # ],
     ]
     query = QueryMatcher(path)
 
@@ -376,25 +362,11 @@ def test_apply(mock_graph_literal):
         root.children[1].children[0].children[0].children[0],
         root.children[1].children[0].children[0].children[0].children[0],
         root.children[1].children[0].children[0].children[0].children[1],
-        # Old-style return value of apply
-        # [
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0].children[0],
-        # ],
-        # [
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0].children[1],
-        # ],
     ]
     query = QueryMatcher(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
     path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
-    # match = [[root, root.children[0], root.children[0].children[0]]]
     match = [root, root.children[0], root.children[0].children[0]]
     query = QueryMatcher(path)
     assert sorted(query.apply(gf)) == sorted(match)
@@ -406,20 +378,6 @@ def test_apply(mock_graph_literal):
         root.children[1].children[0],
         root.children[1].children[0].children[0],
         root.children[1].children[0].children[0].children[0],
-        # Old-style return value of apply
-        # [
-        #     root,
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0],
-        # ],
-        # [
-        #     root,
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        # ],
     ]
     query = QueryMatcher(path)
     assert sorted(query.apply(gf)) == sorted(match)
@@ -538,7 +496,6 @@ def test_high_level_depth(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     query = QueryMatcher([("*", {"depth": 1})])
     roots = gf.graph.roots
-    # matches = [[c] for r in roots for c in r.children]
     matches = [c for r in roots for c in r.children]
     assert sorted(query.apply(gf)) == sorted(matches)
 
@@ -590,7 +547,6 @@ def test_high_level_hatchet_nid(mock_graph_literal):
     assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([{"node_id": 0}])
-    # assert query.apply(gf) == [[gf.graph.roots[0]]]
     assert query.apply(gf) == [gf.graph.roots[0]]
 
     with pytest.raises(InvalidQueryFilter):
@@ -615,7 +571,6 @@ def test_high_level_depth_index_levels(calc_pi_hpct_db):
     assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([("*", {"depth": 0})])
-    # matches = [[root]]
     matches = [root]
     assert query.apply(gf) == matches
 
@@ -640,7 +595,6 @@ def test_high_level_node_id_index_levels(calc_pi_hpct_db):
     assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([("*", {"node_id": 0})])
-    # matches = [[root]]
     matches = [root]
     assert query.apply(gf) == matches
 
@@ -860,14 +814,10 @@ def test_xor_query(mock_graph_literal):
     roots = gf.graph.roots
     matches = [
         roots[0].children[0].children[0],
-        # roots[0].children[0].children[1],
         roots[0].children[1].children[0].children[0].children[0].children[0],
-        # roots[0].children[1].children[0].children[0].children[0].children[1],
-        # roots[0].children[1].children[0].children[0].children[1],
         roots[0].children[2].children[0].children[0],
         roots[0].children[2].children[0].children[1].children[0].children[0],
         roots[1].children[0].children[0],
-        # roots[1].children[0].children[1],
     ]
     assert sorted(compound_query.apply(gf)) == sorted(matches)
 
@@ -880,14 +830,10 @@ def test_sym_diff_query(mock_graph_literal):
     roots = gf.graph.roots
     matches = [
         roots[0].children[0].children[0],
-        # roots[0].children[0].children[1],
         roots[0].children[1].children[0].children[0].children[0].children[0],
-        # roots[0].children[1].children[0].children[0].children[0].children[1],
-        # roots[0].children[1].children[0].children[0].children[1],
         roots[0].children[2].children[0].children[0],
         roots[0].children[2].children[0].children[1].children[0].children[0],
         roots[1].children[0].children[0],
-        # roots[1].children[0].children[1],
     ]
     assert sorted(compound_query.apply(gf)) == sorted(matches)
 
@@ -897,27 +843,15 @@ def test_construct_cypher_api():
     mock_node_ibv = {"name": "ibv_reg_mr"}
     mock_node_time_true = {"time (inc)": 0.1}
     mock_node_time_false = {"time (inc)": 0.001}
-    # path1 = [{"name": "MPI_[_a-zA-Z]*"}, "*", {"name": "ibv[_a-zA-Z]*"}]
     path1 = u"""MATCH (p)->("*")->(q)
     WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
     """
-    # path2 = [{"name": "MPI_[_a-zA-Z]*"}, 2, {"name": "ibv[_a-zA-Z]*"}]
     path2 = u"""MATCH (p)->(2)->(q)
     WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
     """
-    # path3 = [
-    #     {"name": "MPI_[_a-zA-Z]*"},
-    #     ("+", {"time (inc)": ">= 0.1"}),
-    #     {"name": "ibv[_a-zA-Z]*"},
-    # ]
     path3 = u"""MATCH (p)->("+", a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" >= 0.1 AND q."name" STARTS WITH "ibv"
     """
-    # path4 = [
-    #     {"name": "MPI_[_a-zA-Z]*"},
-    #     (3, {"time (inc)": 0.1}),
-    #     {"name": "ibv[_a-zA-Z]*"},
-    # ]
     path4 = u"""MATCH (p)->(3, a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND q."name" STARTS WITH "ibv"
     """
@@ -976,11 +910,6 @@ def test_construct_cypher_api():
     assert not query4.query_pattern[3][1](mock_node_time_false)
     assert query4.query_pattern[4][0] == "."
 
-    # invalid_path = [
-    #     {"name": "MPI_[_a-zA-Z]*"},
-    #     ({"bad": "wildcard"}, {"time (inc)": 0.1}),
-    #     {"name": "ibv[_a-zA-Z]*"},
-    # ]
     invalid_path = u"""MATCH (p)->({"bad": "wildcard"}, a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND
     q."name" STARTS WITH "ibv"
@@ -991,12 +920,6 @@ def test_construct_cypher_api():
 
 def test_apply_cypher(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
-    # path = [
-    #     {"time (inc)": ">= 30.0"},
-    #     (2, {"name": "[^b][a-z]+"}),
-    #     ("*", {"name": "[^b][a-z]+"}),
-    #     {"name": "gr[a-z]+"},
-    # ]
     path = u"""MATCH (p)->(2, q)->("*", r)->(s)
     WHERE p."time (inc)" >= 30.0 AND NOT q."name" STARTS WITH "b"
     AND r."name" =~ "[^b][a-z]+" AND s."name" STARTS WITH "gr"
@@ -1008,26 +931,11 @@ def test_apply_cypher(mock_graph_literal):
         root.children[1].children[0],
         root.children[1].children[0].children[0],
         root.children[1].children[0].children[0].children[1],
-        # Old-style return value of apply
-        # [
-        #     root,
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[1],
-        # ],
-        # [
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[1],
-        # ],
     ]
     query = CypherQuery(path)
 
     assert sorted(query.apply(gf)) == sorted(match)
 
-    # path = [{"time (inc)": ">= 30.0"}, ".", {"name": "bar"}, "*"]
     path = u"""MATCH (p)->(".")->(q)->("*")
     WHERE p."time (inc)" >= 30.0 AND q."name" = "bar"
     """
@@ -1037,33 +945,17 @@ def test_apply_cypher(mock_graph_literal):
         root.children[1].children[0].children[0].children[0],
         root.children[1].children[0].children[0].children[0].children[0],
         root.children[1].children[0].children[0].children[0].children[1],
-        # Old-style return value of apply
-        # [
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0].children[0],
-        # ],
-        # [
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0].children[1],
-        # ],
     ]
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    # path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
     path = u"""MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND r."time" = 5.0
     """
-    # match = [[root, root.children[0], root.children[0].children[0]]]
     match = [root, root.children[0], root.children[0].children[0]]
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    # path = [{"name": "foo"}, {"name": "qux"}, ("+", {"time (inc)": "> 15.0"})]
     path = u"""MATCH (p)->(q)->("+", r)
     WHERE p."name" = "foo" AND q."name" = "qux" AND r."time (inc)" > 15.0
     """
@@ -1073,20 +965,6 @@ def test_apply_cypher(mock_graph_literal):
         root.children[1].children[0],
         root.children[1].children[0].children[0],
         root.children[1].children[0].children[0].children[0],
-        # Old-style return value of apply
-        # [
-        #     root,
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        #     root.children[1].children[0].children[0].children[0],
-        # ],
-        # [
-        #     root,
-        #     root.children[1],
-        #     root.children[1].children[0],
-        #     root.children[1].children[0].children[0],
-        # ],
     ]
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
@@ -1104,7 +982,6 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    # path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
     path = u"""MATCH (p)->("*", q)->(r)
     WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"
     """
@@ -1112,7 +989,6 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert query.apply(gf) == []
 
-    # path = [{"name": 5}, "*", {"name": "whatever"}]
     path = u"""MATCH (p)->("*")->(q)
     WHERE p."name" = 5 AND q."name" = "whatever"
     """
@@ -1120,7 +996,6 @@ def test_apply_cypher(mock_graph_literal):
         query = CypherQuery(path)
         query.apply(gf)
 
-    # path = [{"time": "badstring"}, "*", {"name": "whatever"}]
     path = u"""MATCH (p)->("*")->(q)
     WHERE p."time" = "badstring" AND q."name" = "whatever"
     """
@@ -1139,7 +1014,6 @@ def test_apply_cypher(mock_graph_literal):
         "list"
     ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
-    # path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     path = u"""MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()
     """
@@ -1147,7 +1021,6 @@ def test_apply_cypher(mock_graph_literal):
         query = CypherQuery(path)
         query.apply(gf)
 
-    # path = ["*", {"name": "bar"}, {"name": "grault"}, "*"]
     path = u"""MATCH ("*")->(p)->(q)->("*")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
@@ -1195,7 +1068,6 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    # path = ["*", {"name": "bar"}, {"name": "grault"}, "+"]
     path = u"""MATCH ("*")->(p)->(q)->("+")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
@@ -1322,14 +1194,10 @@ def test_cypher_xor_compound_query(mock_graph_literal):
     roots = gf.graph.roots
     matches = [
         roots[0].children[0].children[0],
-        # roots[0].children[0].children[1],
         roots[0].children[1].children[0].children[0].children[0].children[0],
-        # roots[0].children[1].children[0].children[0].children[0].children[1],
-        # roots[0].children[1].children[0].children[0].children[1],
         roots[0].children[2].children[0].children[0],
         roots[0].children[2].children[0].children[1].children[0].children[0],
         roots[1].children[0].children[0],
-        # roots[1].children[0].children[1],
     ]
     assert sorted(compound_query1.apply(gf)) == sorted(matches)
     assert sorted(compound_query2.apply(gf)) == sorted(matches)

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -1255,13 +1255,13 @@ def test_apply_cypher(mock_graph_literal):
 def test_cypher_and_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_cypher_query(
-        """
+        u"""
         {MATCH ("*", p) WHERE p."time (inc)" >= 20 AND p."time (inc)" <= 60}
         AND {MATCH ("*", p) WHERE p."time (inc)" >= 60}
         """
     )
     compound_query2 = parse_cypher_query(
-        """
+        u"""
         MATCH ("*", p)
         WHERE {p."time (inc)" >= 20 AND p."time (inc)" <= 60} AND {p."time (inc)" >= 60}
         """
@@ -1278,13 +1278,13 @@ def test_cypher_and_compound_query(mock_graph_literal):
 def test_cypher_or_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_cypher_query(
-        """
+        u"""
         {MATCH ("*", p) WHERE p."time (inc)" = 5.0}
         OR {MATCH ("*", p) WHERE p."time (inc)" = 10.0}
         """
     )
     compound_query2 = parse_cypher_query(
-        """
+        u"""
         MATCH ("*", p)
         WHERE {p."time (inc)" = 5.0} OR {p."time (inc)" = 10.0}
         """
@@ -1308,13 +1308,13 @@ def test_cypher_or_compound_query(mock_graph_literal):
 def test_cypher_xor_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_cypher_query(
-        """
+        u"""
         {MATCH ("*", p) WHERE p."time (inc)" >= 5.0 AND p."time (inc)" <= 10.0}
         XOR {MATCH ("*", p) WHERE p."time (inc)" = 10.0}
         """
     )
     compound_query2 = parse_cypher_query(
-        """
+        u"""
         MATCH ("*", p)
         WHERE {p."time (inc)" >= 5.0 AND p."time (inc)" <= 10.0} XOR {p."time (inc)" = 10.0}
         """


### PR DESCRIPTION
This PR is for a feature requested by @cscully-allison, and it is implemented in the `parse_cypher_query` function in `hatchet/query.py`

With this feature, users will be able to create compound queries (i.e., `AndQuery`, `OrQuery`, or `XorQuery`) from within a single mid-level (i.e., Cypher) query. To do this, the two subqueries must be placed within curly braces, and one of the following keywords must be placed between the subqueries:
* `AND`
* `OR`
* `XOR`

These queries can take one of 3 forms.

First, sets of conditions in a mid-level query's `WHERE` clause can be grouped in curly braces. In this case, multiple subqueries that share the same `MATCH` clause will be constructed. Then, they will be combined using the compound queries specified. An example of this type of query is:

```python
literal_query = """MATCH ("*")->(a)->(p)
WHERE {p."name" = "CalcFBHourglassForceForElems"}
AND {NOT a."name" = "LagrangeNodal"}
"""
```

The query in this example will construct two queries:
1. A query which finds 0 or more of any node, followed by one of any node, followed by a node with name `"CalcFBHourglassForceForElems"`
2. A query which finds 0 or more of any node, followed by a node without the name `"LagrangeNodal"`, followed by one of any node

After constructing these queries, the intersection of the two queries will be determined using `AndQuery`. This intersection is what will be returned to the user.

In the second form, entire mid-level queries (i.e., both `MATCH` and `WHERE` clauses) are enclosed in curly braces. In this case, all the individual queries will be constructed. Then, they will be combined using the compound queries specified. An example of this type of query is:

```python
literal_query = """{MATCH ("*")->(p)
WHERE p."name" = "leaf_a" OR p."name" = "leaf_b"}
AND {MATCH (a) WHERE NOT a."name" = "inner_a"
AND NOT a."name" = "inner_b"}
"""
```

The query in this example will construct two queries:
1. A query which finds all paths from the root of the tree to nodes named either `"leaf_a"` or `"leaf_b"`
2. A query which finds all nodes that don't have the name `"inner_a"` or `"inner_b"`

After constructing these queries, the intersection of the two queries will be determined using `AndQuery`. This intersection is what will be returned to the user.

In the third form, both of the two forms above can be combined. So, each full query in curly braces (case 2) will have curly brace-delimited regions in its `WHERE` clause (case 1). In this case, each full query will be processed by recursively calling `parse_cypher_query`. Then, the entire query will be processed in the same way as case 2.

A use case for this feature is trying to do the following in a single mid-level query:
1. Find all paths from the roots to a node called `"leaf_a"`
2. Remove all nodes named `"inner_b"` from the `GraphFrame`

With this feature, both of these tasks can be completed with the following single query:

```python
literal_query = """{MATCH ("*")->(p)
WHERE p."name" = "leaf_a"}
AND {MATCH (a) WHERE NOT a."name" = "inner_b"}
"""
```