### PR TITLE
add default_metric and metadata to copy and deepcopy

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -322,6 +322,8 @@ class GraphFrame:
             self.dataframe.copy(),
             list(self.exc_metrics),
             list(self.inc_metrics),
+            self.default_metric,
+            self.metadata,
         )
 
     def deepcopy(self):
@@ -338,7 +340,12 @@ class GraphFrame:
         dataframe_copy.set_index(index_names, inplace=True)
 
         return GraphFrame(
-            graph_copy, dataframe_copy, list(self.exc_metrics), list(self.inc_metrics)
+            graph_copy,
+            dataframe_copy,
+            list(self.exc_metrics),
+            list(self.inc_metrics),
+            self.default_metric,
+            self.metadata,
         )
 
     def drop_index_levels(self, function=np.mean):

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -31,6 +31,8 @@ def test_copy(mock_graph_literal):
     assert gf.dataframe.equals(other.dataframe)
     assert gf.inc_metrics == other.inc_metrics
     assert gf.exc_metrics == other.exc_metrics
+    assert gf.default_metric == other.default_metric
+    assert gf.metadata == other.metadata
 
 
 def test_deepcopy(mock_graph_literal):
@@ -41,6 +43,8 @@ def test_deepcopy(mock_graph_literal):
     assert gf.dataframe is not other.dataframe
     assert gf.inc_metrics == other.inc_metrics
     assert gf.exc_metrics == other.exc_metrics
+    assert gf.default_metric == other.default_metric
+    assert gf.metadata == other.metadata
 
 
 def test_drop_index_levels(calc_pi_hpct_db):


### PR DESCRIPTION
Return default_metric and metadata when creating a copy or a deepcopy of the
graphframe