### PR TITLE
Adds a GitHub Action to test PyPI Releases on a Regular Schedule

### DIFF
--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -2,13 +2,13 @@ name: pip install tester
 
 on:
   # Uncomment these lines for testing
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop, releases/** ]
+  # push:
+  #   branches: [ develop ]
+  # pull_request:
+  #   branches: [ develop, releases/** ]
   # Uncomment these lines for production
-  # schedule:
-  #   - cron: '0 0 1 JAN,MAY,AUG,NOV *'
+  schedule:
+    - cron: '0 0 1 JAN,MAY,AUG,NOV *'
 
 jobs:
   pip_test:
@@ -34,12 +34,6 @@ jobs:
     - name: Build unit test dependencies
       run: |
         python -m pip install --upgrade pip pytest
-
-    - name: Build Python 2.7 dependencies
-      if: ${{ matrix.python-version == 2.7 }}
-      run: |
-        python -m pip install --upgrade numexpr==2.7.3
-        python -m pip install tables==3.5.2 # Last version of tables to support Python 2.7
 
     - name: Build Python 3 dependencies
       if: ${{ matrix.python-version != 2.7 }}

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -15,6 +15,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
@@ -45,16 +46,41 @@ jobs:
       run: |
         python -m pip install tables
 
-    - name: Show packages
-      run: |
-        python -m pip list
-
     - name: Install Hatchet
       env:
         HATCHET_VERSION: ${{ matrix.hatchet-version }}
       run: |
+        curr_dir=$(pwd)
+        cd ~
         python -m pip install llnl-hatchet==$HATCHET_VERSION
+        cd $curr_dir
+
+    - name: Show packages
+      run: |                                                                
+        python -m pip list                                                  
+                                                                            
+    - name: Prep tests                                                      
+      env:                                                                  
+        HATCHET_VERSION: ${{ matrix.hatchet-version }}                      
+        PYTHON_VERSION: ${{ matrix.python-version }}                        
+      run: |
+        cp -r ./hatchet/tests ~
+        test_dir="tests-$HATCHET_VERSION-$PYTHON_VERSION"
+        mv ~/tests ~/$test_dir
+        cat > ~/$test_dir/pytest.ini << EOF
+        [pytest]
+        addopts = --durations=20 -ra
+        testpaths = .
+        python_files = *.py
+        EOF
 
     - name: Test Hatchet
+      env:
+        HATCHET_VERSION: ${{ matrix.hatchet-version }}
+        PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        pytest -vv .
+        curr_dir=$(pwd)
+        cd ~
+        test_dir="tests-$HATCHET_VERSION-$PYTHON_VERSION"
+        pytest -vv $test_dir
+        cd $curr_dir

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -34,15 +34,25 @@ jobs:
       run: |
         python -m pip install --upgrade pip pytest
 
-    - name: Build optional dependencies for HDF
+    - name: Build Python 2.7 dependencies
+      if: ${{ matrix.python-version == 2.7 }}
+      run: |
+        python -m pip install --upgrade numexpr==2.7.3
+        python -m pip install tables==3.5.2 # Last version of tables to support Python 2.7
+
+    - name: Build Python 3 dependencies
+      if: ${{ matrix.python-version != 2.7 }}
       run: |
         python -m pip install tables
+
+    - name: Show packages
+      run: |
+        python -m pip list
 
     - name: Install Hatchet
       env:
         HATCHET_VERSION: ${{ matrix.hatchet-version }}
       run: |
-        # TODO Change the package from "hatchet" to "llnl-hatchet"
         python -m pip install llnl-hatchet==$HATCHET_VERSION
 
     - name: Test Hatchet

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-        hatchet-version: ['2022.1.0', '2022.1.1']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        hatchet-version: ['2022.1.0', '2022.1.1', "2022.2.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -2,13 +2,13 @@ name: pip install tester
 
 on:
   # Uncomment these lines for testing
-  # push:
-  #   branches: [ develop ]
-  # pull_request:
-  #   branches: [ develop, releases/** ]
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop, releases/** ]
   # Uncomment these lines for production
-  schedule:
-    - cron: '0 0 1 JAN,MAY,AUG,NOV *'
+  # schedule:
+  #   - cron: '0 0 1 JAN,MAY,AUG,NOV *'
 
 jobs:
   pip_test:

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         hatchet-version: ["2022.2.0"]
 
     steps:

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-        hatchet-version: ['2022.1.0', '2022.1.1', "2022.2.0"]
+        hatchet-version: ["2022.2.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -1,0 +1,50 @@
+name: pip install tester
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop, releases/** ]
+  # TODO Replace the workflow_dispatch to schedule
+  # schedule:
+  #   # - cron: '0 16 16 * *'
+  #   - cron: '0 16 * * *'
+
+jobs:
+  pip_test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        hatchet-version: ['2022.1.0', '2022.1.1']
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ format('v{0}', matrix.hatchet-version) }}
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Build unit test dependencies
+      run: |
+        python -m pip install --upgrade pip pytest
+
+    - name: Build optional dependencies for HDF
+      run: |
+        python -m pip install tables
+
+    - name: Install Hatchet
+      env:
+        HATCHET_VERSION: ${{ matrix.hatchet-version }}
+      run: |
+        # TODO Change the package from "hatchet" to "llnl-hatchet"
+        python -m pip install llnl-hatchet==$HATCHET_VERSION
+
+    - name: Test Hatchet
+      run: |
+        pytest -vv .

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -1,12 +1,14 @@
 name: pip install tester
 
 on:
-  # push:
-  #   branches: [ develop ]
-  # pull_request:
-  #   branches: [ develop, releases/** ]
-  schedule:
-    - cron: '0 0 1 JAN,MAY,AUG,NOV *'
+  # Uncomment these lines for testing
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop, releases/** ]
+  # Uncomment these lines for production
+  # schedule:
+  #   - cron: '0 0 1 JAN,MAY,AUG,NOV *'
 
 jobs:
   pip_test:

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -1,14 +1,12 @@
 name: pip install tester
 
 on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop, releases/** ]
-  # TODO Replace the workflow_dispatch to schedule
-  # schedule:
-  #   # - cron: '0 16 16 * *'
-  #   - cron: '0 16 * * *'
+  # push:
+  #   branches: [ develop ]
+  # pull_request:
+  #   branches: [ develop, releases/** ]
+  schedule:
+    - cron: '0 0 1 JAN,MAY,AUG,NOV *'
 
 jobs:
   pip_test:

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -2,13 +2,13 @@ name: pip install tester
 
 on:
   # Uncomment these lines for testing
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop, releases/** ]
+  # push:
+  #   branches: [ develop ]
+  # pull_request:
+  #   branches: [ develop, releases/** ]
   # Uncomment these lines for production
-  # schedule:
-  #   - cron: '0 0 1 JAN,MAY,AUG,NOV *'
+  schedule:
+    - cron: '0 0 1 JAN,MAY,AUG,NOV *'
 
 jobs:
   pip_test:


### PR DESCRIPTION
This PR is created in response to https://github.com/hatchet/hatchet/issues/443.

This PR adds a new GitHub Action that essentially performs automated regression testing on PyPI releases. It will install each considered version of Hatchet under each considered version of Python, checkout that Hatchet version's release branch, and perform the version's unit tests.

The following Hatchet versions are currently considered:
* v1.2.0 (omitted, missing writers module)
* v1.3.0 (omitted, missing writers module)
* v1.3.1a0 (omitted, missing writers module)
* 2022.1.0 (omitted, missing writers module)
* 2022.1.1 (omitted, missing writers module)
* 2022.2.0 (omitted, missing writers module)

Similarly, the following versions of Python are currently considered:
* 2.7 (omitted, missing version in docker)
* 3.5 (omitted, missing version in docker)
* 3.6
* 3.7
* 3.8 
* 3.9

Before merging, the following tasks must be done:
- [X] ~Replace the `workflow_dispatch` (i.e., manual) trigger with the commented out `schedule` trigger in `pip_unit_tester.yaml`~ Superseded by a task in a later comment
- [x] Change the "Install Hatchet" step to install `llnl-hatchet` instead of `hatchet`. This will be changed once the `llnl-hatchet` package goes live on PyPI