### PR TITLE
add default_metric and metadata to filter and squash

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -448,6 +448,8 @@ class GraphFrame:
         filtered_gf = GraphFrame(self.graph, filtered_df)
         filtered_gf.exc_metrics = self.exc_metrics
         filtered_gf.inc_metrics = self.inc_metrics
+        filtered_gf.default_metric = self.default_metric
+        filtered_gf.metadata = self.metadata
 
         if squash:
             return filtered_gf.squash()
@@ -541,7 +543,14 @@ class GraphFrame:
         agg_df.sort_index(inplace=True)
 
         # put it all together
-        new_gf = GraphFrame(graph, agg_df, self.exc_metrics, self.inc_metrics)
+        new_gf = GraphFrame(
+            graph,
+            agg_df,
+            self.exc_metrics,
+            self.inc_metrics,
+            self.default_metric,
+            self.metadata,
+        )
         new_gf.update_inclusive_columns()
         return new_gf
 
@@ -1169,7 +1178,14 @@ class GraphFrame:
         graph.enumerate_traverse()
 
         # put it all together
-        new_gf = GraphFrame(graph, tmp_df, self.exc_metrics, self.inc_metrics)
+        new_gf = GraphFrame(
+            graph,
+            tmp_df,
+            self.exc_metrics,
+            self.inc_metrics,
+            self.default_metric,
+            self.metadata,
+        )
         new_gf.drop_index_levels()
         return new_gf
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -167,6 +167,8 @@ def check_filter_no_squash(gf, filter_func, num_rows):
     assert filtered.graph is gf.graph
     assert filtered.graph == orig_graph
     assert len(filtered.dataframe) == num_rows
+    assert filtered.default_metric == gf.default_metric
+    assert filtered.metadata == gf.metadata
 
     # parallel versions of the same test
     orig_graph = gf.graph.copy()
@@ -176,6 +178,8 @@ def check_filter_no_squash(gf, filter_func, num_rows):
     assert filtered.graph is gf.graph
     assert filtered.graph == orig_graph
     assert len(filtered.dataframe) == num_rows
+    assert filtered.default_metric == gf.default_metric
+    assert filtered.metadata == gf.metadata
 
 
 def check_filter_squash(gf, filter_func, expected_graph, expected_inc_time):
@@ -210,6 +214,9 @@ def check_filter_squash(gf, filter_func, expected_graph, expected_inc_time):
     assert expected_inc_time == [
         filtered_squashed.dataframe.loc[node, "time (inc)"] for node in nodes
     ]
+
+    assert filtered_squashed.default_metric == gf.default_metric
+    assert filtered_squashed.metadata == gf.metadata
 
     # parallel versions
     filtered_squashed = gf.filter(filter_func)


### PR DESCRIPTION
Save default_metric and metadata when filtering or squashing the graphframe,
update related unit tests