### PR TITLE
set self.colors to a copy of the colormap list

### DIFF
--- a/hatchet/util/colormaps.py
+++ b/hatchet/util/colormaps.py
@@ -95,7 +95,7 @@ class ColorMaps:
         "\033[38;5;26m",  # Dark Blue
     ]
 
-    def __init(self):
+    def __init__(self):
         self.colors = []
 
     def get_colors(self, colormap, invert_colormap):
@@ -104,25 +104,25 @@ class ColorMaps:
         """
 
         if colormap == "RdYlGn":
-            self.colors = self.RdYlGn
+            self.colors = self.RdYlGn.copy()
         elif colormap == "BrBG":
-            self.colors = self.BrBG
+            self.colors = self.BrBG.copy()
         elif colormap == "PiYG":
-            self.colors = self.PiYG
+            self.colors = self.PiYG.copy()
         elif colormap == "PRGn":
-            self.colors = self.PRGn
+            self.colors = self.PRGn.copy()
         elif colormap == "PiYG":
-            self.colors = self.PiYG
+            self.colors = self.PiYG.copy()
         elif colormap == "PuOr":
-            self.colors = self.PuOr
+            self.colors = self.PuOr.copy()
         elif colormap == "RdBu":
-            self.colors = self.RdBu
+            self.colors = self.RdBu.copy()
         elif colormap == "RdGy":
-            self.colors = self.RdGy
+            self.colors = self.RdGy.copy()
         elif colormap == "RdYlBu":
-            self.colors = self.RdYlBu
+            self.colors = self.RdYlBu.copy()
         elif colormap == "Spectral":
-            self.colors = self.Spectral
+            self.colors = self.Spectral.copy()
         else:
             raise ValueError(
                 self.colormap


### PR DESCRIPTION
Original assignment of colormaps to self.colors resulted in both lists pointing
to the same list. When reversing self.colors, this impacted the colormap and
colors list, resulting in inconsistent tree outputs when making multiple
calls to tree().