### PR TITLE
Adds the ability to match leaf nodes in the Query Language

### DIFF
--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -820,7 +820,7 @@ class CypherQuery(QueryMatcher):
             cname(obj) == "NotCond"
             or self._is_str_cond(obj)
             or self._is_num_cond(obj)
-            or cname(obj) in ["NoneCond", "NotNoneCond"]
+            or cname(obj) in ["NoneCond", "NotNoneCond", "LeafCond", "NotLeafCond"]
         ):
             return True
         return False

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -1048,8 +1048,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1071,8 +1073,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1102,8 +1106,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1125,8 +1131,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1156,8 +1164,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1179,8 +1189,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1210,13 +1222,15 @@ class CypherQuery(QueryMatcher):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
                     obj.name,
-                    "False"
+                    "False",
                     "isinstance(df_row.name._depth, Real)",
                 ]
             return [
@@ -1233,8 +1247,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1264,8 +1280,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,
@@ -1287,8 +1305,10 @@ class CypherQuery(QueryMatcher):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
-                    RedundantQueryFilterWarning
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
                 )
                 return [
                     None,

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -16,6 +16,7 @@ from itertools import groupby
 from numbers import Real
 import re
 import sys
+import warnings
 import pandas as pd
 from pandas import DataFrame
 from pandas.core.indexes.multi import MultiIndex
@@ -1040,6 +1041,22 @@ class CypherQuery(QueryMatcher):
                     "len(df_row.name.children) == 0",
                     None,
                 ]
+            elif obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.name._depth, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1047,6 +1064,22 @@ class CypherQuery(QueryMatcher):
                 "isinstance(df_row.name._depth, Real)",
             ]
         if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.name._hatchet_nid, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1062,6 +1095,22 @@ class CypherQuery(QueryMatcher):
 
     def _parse_num_lt(self, obj):
         if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.name._depth, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1069,6 +1118,22 @@ class CypherQuery(QueryMatcher):
                 "isinstance(df_row.name._depth, Real)",
             ]
         if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.name._hatchet_nid, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1084,6 +1149,22 @@ class CypherQuery(QueryMatcher):
 
     def _parse_num_gt(self, obj):
         if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.name._depth, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1091,6 +1172,22 @@ class CypherQuery(QueryMatcher):
                 "isinstance(df_row.name._depth, Real)",
             ]
         if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.name._hatchet_nid, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1106,6 +1203,22 @@ class CypherQuery(QueryMatcher):
 
     def _parse_num_lte(self, obj):
         if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False"
+                    "isinstance(df_row.name._depth, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1113,6 +1226,22 @@ class CypherQuery(QueryMatcher):
                 "isinstance(df_row.name._depth, Real)",
             ]
         if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.name._hatchet_nid, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1128,6 +1257,22 @@ class CypherQuery(QueryMatcher):
 
     def _parse_num_gte(self, obj):
         if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.name._depth, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1135,6 +1280,22 @@ class CypherQuery(QueryMatcher):
                 "isinstance(df_row.name._depth, Real)",
             ]
         if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(obj),
+                    RedundantQueryFilterWarning
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.name._hatchet_nid, Real)",
+                ]
             return [
                 None,
                 obj.name,
@@ -1539,6 +1700,10 @@ class InvalidQueryPath(Exception):
 
 class InvalidQueryFilter(Exception):
     """Raised when a query filter does not have a valid syntax"""
+
+
+class RedundantQueryFilterWarning(Warning):
+    """Warned when a query filter does nothing or is redundant"""
 
 
 class BadNumberNaryQueryArgs(Exception):

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -1211,3 +1211,39 @@ def test_cypher_xor_compound_query(mock_graph_literal):
     ]
     assert sorted(compound_query1.apply(gf)) == sorted(matches)
     assert sorted(compound_query2.apply(gf)) == sorted(matches)
+
+
+def test_leaf_query(small_mock2):
+    gf = GraphFrame.from_literal(small_mock2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[0].children[0],
+        roots[0].children[0].children[1],
+        roots[0].children[1].children[0],
+        roots[0].children[1].children[1],
+    ]
+    nodes = set(gf.graph.traverse())
+    nonleaves = list(nodes - set(matches))
+    obj_query = QueryMatcher([{"depth": -1}])
+    str_query_numeric = parse_cypher_query(
+        u"""
+        MATCH (p)
+        WHERE p."depth" = -1
+        """
+    )
+    str_query_is_leaf = parse_cypher_query(
+        u"""
+        MATCH (p)
+        WHERE p IS LEAF
+        """
+    )
+    str_query_is_not_leaf = parse_cypher_query(
+        u"""
+        MATCH (p)
+        WHERE p IS NOT LEAF
+        """
+    )
+    assert sorted(obj_query.apply(gf)) == sorted(matches)
+    assert sorted(str_query_numeric.apply(gf)) == sorted(matches)
+    assert sorted(str_query_is_leaf.apply(gf)) == sorted(matches)
+    assert sorted(str_query_is_not_leaf.apply(gf)) == sorted(nonleaves)


### PR DESCRIPTION
This is resolves a feature request brought to my attention by @slabasan 

This PR adds the ability to check if a node is a leaf node in predicates in the String dialect (mid-level) and Object dialect (high-level). This functionality was technically available in the main Query Language through the following:
```python
lambda row: len(row.name.children) == 0
```

With this PR, this "match if node is a leaf" functionality is enabled in three ways.

In the Object dialect (high-level), a user can check if a node is a leaf using the predicate `{"depth": -1}`.

In the String dialect (mid-level), a user can perform this check in one of two ways. 

The first way mimics the Object dialect and can be performed with the following:
```python
query = """
MATCH (".", p)
WHERE p."depth" = -1
"""
```

The second String dialect (mid-level) approach is using the new `p IS LEAF` and `p IS NOT LEAF` predicates. We should discuss if we want to include these or not since they depart from the normal `"var.'metric' <operation>"` format that all other predicates use.

To complement this addition, I've also added warnings ("raised" with `warnings.warn`) to the String and Object dialects (Object still pending) when the `depth` and `node_id` metrics are compared to negative values. These warnings simply inform the user that `depth` and `node_id` are strictly non-negative, so comparing those metrics with negative values (excluding the special case of -1) will produce predicates that are always true or false.