### PR TITLE
Adds CITATION.cff for autogeneration of BibTex citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+title: Hatchet
+message: "If you use Hatchet, please cite it as below."
+repository-code: https://github.com/LLNL/hatchet
+preferred-citation:
+  type: conference-paper
+  doi: 10.1145/3295500.3356219
+  url: https://github.com/LLNL/hatchet
+  authors:
+  - family-names: Bhatele
+    given-names: Abhinav
+  - family-names: Brink
+    given-names: Stephanie
+  - family-names: Gamblin
+    given-names: Todd
+  title: "Hatchet: Pruning the Overgrowth in Parallel Profiles"
+  conference:
+    name: "International Conference for High Performance Computing, Networking, Storage and Analysis (SC '19)"
+    city: "Denver"
+    region: "Colorado"
+    country: "USA"
+    date-start: 2019-11-17
+    date-end: 2019-11-22
+  year: 2019
+  notes: LLNL-CODE-741008
+  publisher:
+    name: ACM
+    city: "New York"
+    region: "New York"
+    country: "USA"


### PR DESCRIPTION
This PR adds a `CITATION.cff` file that will add the "Cite this Repository" button to the GitHub repo. This `cff` file will produce a citation to the original Hatchet paper. An example of what this looks like is shown in the following image:
![image](https://user-images.githubusercontent.com/28907237/171462403-b3dfe866-6c08-4895-a642-5339a54fcda5.png)

Additionally, the BibTex citation that is generated is as follows:
```bibtex
@inproceedings{Bhatele_Hatchet_Pruning_the_2019,
address = {Denver, Colorado, USA},
author = {Bhatele, Abhinav and Brink, Stephanie and Gamblin, Todd},
doi = {10.1145/3295500.3356219},
month = {11},
note = {LLNL-CODE-741008},
publisher = {ACM},
series = {International Conference for High Performance Computing, Networking, Storage and Analysis (SC '19)},
title = {{Hatchet: Pruning the Overgrowth in Parallel Profiles}},
url = {https://github.com/LLNL/hatchet},
year = {2019}
}
```

If you want to try this feature out, you can do so in the GCLab fork of this repo: https://github.com/TauferLab/llnl-hatchet/tree/citation