### PR TITLE
Error when rel is called before match in base Query Language

### DIFF
--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -429,6 +429,10 @@ class QueryMatcher(AbstractQuery):
         Returns:
             (QueryMatcher): The instance of the class that called this function (enables fluent design).
         """
+        if len(self.query_pattern) == 0:
+            raise InvalidQueryPath(
+                "Queries in the base Query Language must start with a call to 'match'"
+            )
         self._add_node(wildcard_spec, filter_func)
         return self
 

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -213,6 +213,9 @@ def test_construct_low_level_api():
     assert not query.query_pattern[3][1](mock_node_time_false)
     assert query.query_pattern[4][0] == "."
 
+    with pytest.raises(InvalidQueryPath):
+        _ = QueryMatcher().rel(".", lambda row: True)
+
 
 def test_node_caching(mock_graph_literal):
     path = [{"name": "fr[a-z]+"}, ("+", {"time (inc)": ">= 25.0"}), {"name": "baz"}]


### PR DESCRIPTION
In the base Query Language, the `match` function should always be called to start a query. As a result, it should be expected that `rel` would raise an error if it is called before `match`. However, as discovered by @vanessalama09, the `rel` function currently does not raise any error in this situation.

So, this PR adds that error raising to `QueryMatcher.rel`. It also adds a unit test to confirm that an `InvalidQueryPath` error occurs when `rel` is called before `match`.