### PR TITLE
Adds the "hatchet.writers" module to pip installations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     packages=[
         "hatchet",
         "hatchet.readers",
+        "hatchet.writers",
         "hatchet.util",
         "hatchet.external",
         "hatchet.tests",


### PR DESCRIPTION
While working on #29, I realized that the `hatchet.writers` module was not being included in pip installation. This is a problem because the `writers` module is what is providing, for example, Hatchet's ability to checkpoint `GraphFrame` objects to HDF5 files.

This PR tweaks `setup.py` to provide `hatchet.writers` in pip installation.