### PR TITLE
Add beautiful soup 4 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ cython
 multiprocess
 textX
 caliper-reader
+beautifulsoup4


### PR DESCRIPTION
Added `beautifulsoup4` to the list of required packages to resolve install issues where bs4 package could not be found.