### PR TITLE
Modify Hatchet copy/deepcopy

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -331,7 +331,7 @@ class GraphFrame:
         """
         return GraphFrame(
             self.graph,
-            self.dataframe.copy(deep=False),  # copy to prevent dataframe mutation operations from modifying the original.
+            self.dataframe.copy(deep=False),
             copy.copy(self.exc_metrics),
             copy.copy(self.inc_metrics),
             self.default_metric,

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -359,7 +359,9 @@ class GraphFrame:
 
         index_names = dataframe_copy.index.names
         dataframe_copy.reset_index(inplace=True)
+
         dataframe_copy["node"] = dataframe_copy["node"].apply(lambda x: node_clone[x])
+
         dataframe_copy.set_index(index_names, inplace=True)
 
         return GraphFrame(

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -2,6 +2,7 @@
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+
 import copy
 import sys
 import traceback

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -2,7 +2,7 @@
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
-
+import copy
 import sys
 import traceback
 
@@ -313,40 +313,62 @@ class GraphFrame:
         HDF5Writer(filename).write(self, key=key, **kwargs)
 
     def copy(self):
-        """Return a shallow copy of the graphframe.
+        """Return a partially shallow copy of the graphframe.
 
-        This copies the DataFrame, but the Graph is shared between self and
-        the new GraphFrame.
+        This copies the DataFrame object, but the data is comprised of references. The Graph is shared between self and the new GraphFrame.
+
+        Arguments:
+            self (GraphFrame): Object to make a copy of.
+
+        Returns:
+            other (GraphFrame): Copy of self
+                graph (graph): Reference to self's graph
+                dataframe (DataFrame): Pandas "non-deep" copy of dataframe
+                exc_metrics (list): Copy of self's exc_metrics
+                inc_metrics (list): Copy of self's inc_metrics
+                default_metric (str): N/A
+                metadata (dict): Copy of self's metadata
         """
         return GraphFrame(
             self.graph,
-            self.dataframe.copy(),
-            list(self.exc_metrics),
-            list(self.inc_metrics),
+            self.dataframe.copy(deep=False),  # copy to prevent dataframe mutation operations from modifying the original.
+            copy.copy(self.exc_metrics),
+            copy.copy(self.inc_metrics),
             self.default_metric,
-            self.metadata,
+            copy.copy(self.metadata),
         )
 
     def deepcopy(self):
-        """Return a copy of the graphframe."""
+        """Return a deep copy of the graphframe.
+
+        Arguments:
+            self (GraphFrame): Object to make a copy of.
+
+        Returns:
+            other (GraphFrame): Copy of self
+                graph (graph): Deep copy of self's graph
+                dataframe (DataFrame): Pandas "deep" copy with node objects updated to match graph from "node_clone"
+                exc_metrics (list): Copy of self's exc_metrics
+                inc_metrics (list): Copy of self's inc_metrics
+                default_metric (str): N/A
+                metadata (dict): Copy of self's metadata
+        """
         node_clone = {}
         graph_copy = self.graph.copy(node_clone)
         dataframe_copy = self.dataframe.copy()
 
         index_names = dataframe_copy.index.names
         dataframe_copy.reset_index(inplace=True)
-
         dataframe_copy["node"] = dataframe_copy["node"].apply(lambda x: node_clone[x])
-
         dataframe_copy.set_index(index_names, inplace=True)
 
         return GraphFrame(
             graph_copy,
             dataframe_copy,
-            list(self.exc_metrics),
-            list(self.inc_metrics),
+            copy.deepcopy(self.exc_metrics),
+            copy.deepcopy(self.inc_metrics),
             self.default_metric,
-            self.metadata,
+            copy.deepcopy(self.metadata),
         )
 
     def drop_index_levels(self, function=np.mean):

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -23,28 +23,39 @@ from hatchet.external.console import ConsoleRenderer
 
 
 def test_copy(mock_graph_literal):
-    gf = GraphFrame.from_literal(mock_graph_literal)
-    other = gf.copy()
+    self = GraphFrame.from_literal(mock_graph_literal)
+    other = self.copy()
 
-    assert gf.graph is other.graph
-    assert gf.dataframe is not other.dataframe
-    assert gf.dataframe.equals(other.dataframe)
-    assert gf.inc_metrics == other.inc_metrics
-    assert gf.exc_metrics == other.exc_metrics
-    assert gf.default_metric == other.default_metric
-    assert gf.metadata == other.metadata
+    assert self is not other
+    assert self.graph is other.graph
+    assert self.graph == other.graph
+    assert self.dataframe is not other.dataframe
+    assert self.dataframe.equals(other.dataframe)
+    assert self.exc_metrics is not other.exc_metrics
+    assert self.exc_metrics == other.exc_metrics
+    assert self.inc_metrics is not other.inc_metrics
+    assert self.inc_metrics == other.inc_metrics
+    assert self.default_metric == other.default_metric
+    assert self.metadata is not other.metadata
+    assert self.metadata == other.metadata
 
 
 def test_deepcopy(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     other = gf.deepcopy()
 
-    assert gf.graph == other.graph
-    assert gf.dataframe is not other.dataframe
-    assert gf.inc_metrics == other.inc_metrics
-    assert gf.exc_metrics == other.exc_metrics
-    assert gf.default_metric == other.default_metric
-    assert gf.metadata == other.metadata
+    assert self is not other
+    assert self.graph is not other.graph
+    assert self.graph == other.graph
+    assert self.dataframe is not other.dataframe
+    assert self.dataframe.equals(other.dataframe)
+    assert self.exc_metrics is not other.exc_metrics
+    assert self.exc_metrics == other.exc_metrics
+    assert self.inc_metrics is not other.inc_metrics
+    assert self.inc_metrics == other.inc_metrics
+    assert self.default_metric == other.default_metric
+    assert self.metadata is not other.metadata
+    assert self.metadata == other.metadata
 
 
 def test_drop_index_levels(calc_pi_hpct_db):

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -41,8 +41,8 @@ def test_copy(mock_graph_literal):
 
 
 def test_deepcopy(mock_graph_literal):
-    gf = GraphFrame.from_literal(mock_graph_literal)
-    other = gf.deepcopy()
+    self = GraphFrame.from_literal(mock_graph_literal)
+    other = self.deepcopy()
 
     assert self is not other
     assert self.graph is not other.graph


### PR DESCRIPTION
# Summary
Docstrings for both `copy`/`deepcopy` have been elaborated on. Added to the unit tests and adjusted some tests to reflect code changes.
These changes are related to the changes being made in [thicket](https://lc.llnl.gov/gitlab/pave/thicket/-/merge_requests/14/diffs).
### copy
- `deep=False` added to dataframe copy to better enforce shallow behavior.
- `list` return type changed to `copy.copy()`. These have the same result here, but I think it is more clear what is happening by explicitly calling copy.
- `copy.copy()` added to metadata to follow behavior of `exc_metrics` and `inc_metrics`. It also makes sense to add the copy to reflect other's state.
** Note that usage of `copy.copy()` when the lists do not contain objects themselves essentially is the same as `copy.deepcopy()`. The behavior should differ when there are objects inside.
### deepcopy
- Same changes as in copy to `exc_metrics`, `inc_metrics` and `metadata`, except `copy.deepcopy()` used here. This ensures the deepcopying of any objects contained in these attributes.