### PR TITLE
add function to parse caliper metadata

### DIFF
--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -244,10 +244,11 @@ class CaliperNativeReader:
     def _parse_metadata(self, mdata):
         """Convert Caliper Metadata values into correct Python objects.
 
-        :param mdata: the metadata to convert
-        :type mdata: Dict[str, str]
-        :return: the converted metadata
-        :rtype: Dict[str, str]
+        Args:
+            mdata (dict[str: str]): metadata to convert
+
+        Return:
+            (dict[str: str]): modified metadata
         """
         parsed_mdata = {}
         for k, v in mdata.items():

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -241,6 +241,39 @@ class CaliperNativeReader:
 
         return list_roots
 
+    def _parse_metadata(self, mdata):
+        """Convert Caliper Metadata values into correct Python objects.
+
+        :param mdata: the metadata to convert
+        :type mdata: Dict[str, str]
+        :return: the converted metadata
+        :rtype: Dict[str, str]
+        """
+        parsed_mdata = {}
+        for k, v in mdata.items():
+            # If the value is an int, convert it to an int.
+            try:
+                parsed_mdata[k] = int(v)
+            except ValueError:
+                # If the value is a float, convert it to a float
+                try:
+                    parsed_mdata[k] = float(v)
+                except ValueError:
+                    # If the value is a list or tuple, convert it to a list or
+                    # tuple
+                    if v.startswith("[") and v.endswith("]"):
+                        parsed_mdata[k] = [
+                            elem.strip() for elem in v.strip("][").split(",")
+                        ]
+                    elif v.startswith("(") and v.endswith(")"):
+                        parsed_mdata[k] = [
+                            elem.strip() for elem in v.strip(")(").split(",")
+                        ]
+                    # If the value is a string, just save it as-is
+                    else:
+                        parsed_mdata[k] = v
+        return parsed_mdata
+
     def read(self):
         """Read the caliper records to extract the calling context tree."""
         if isinstance(self.filename_or_caliperreader, str):
@@ -370,6 +403,7 @@ class CaliperNativeReader:
                 self.default_metric = exc_metrics[0]
 
         metadata = self.filename_or_caliperreader.globals
+        parsed_metadata = self._parse_metadata(metadata)
 
         return hatchet.graphframe.GraphFrame(
             graph,
@@ -377,5 +411,5 @@ class CaliperNativeReader:
             exc_metrics,
             inc_metrics,
             self.default_metric,
-            metadata=metadata,
+            metadata=parsed_metadata,
         )

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -226,6 +226,9 @@ def test_graphframe_native_lulesh_from_file(lulesh_caliper_cali):
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 
+    assert type(gf.metadata["cali.channel"]) == str
+    assert type(gf.metadata["cali.caliper.version"]) == str
+
 
 @pytest.mark.skipif(
     not caliperreader_avail, reason="needs caliper-reader package to be loaded"
@@ -239,6 +242,7 @@ def test_graphframe_native_lulesh_from_caliperreader(lulesh_caliper_cali):
 
     assert len(gf.dataframe.groupby("name")) == 19
     assert "cali.caliper.version" in gf.metadata.keys()
+    assert type(gf.metadata["cali.caliper.version"]) == str
 
     for col in gf.dataframe.columns:
         if col in ("time (inc)", "time"):
@@ -284,6 +288,10 @@ def test_sw4_cuda_from_caliperreader(sw4_caliper_cuda_activity_profile_cali):
     for col in gf.exc_metrics + gf.inc_metrics:
         assert col in gf.dataframe.columns
 
+    assert type(gf.metadata["mpi.world.size"]) == int
+    assert type(gf.metadata["cali.caliper.version"]) == str
+    assert type(gf.metadata["cali.channel"]) == str
+
 
 def test_sw4_cuda_summary_from_caliperreader(
     sw4_caliper_cuda_activity_profile_summary_cali,
@@ -297,3 +305,7 @@ def test_sw4_cuda_summary_from_caliperreader(
 
     for col in gf.exc_metrics + gf.inc_metrics:
         assert col in gf.dataframe.columns
+
+    assert type(gf.metadata["mpi.world.size"]) == int
+    assert type(gf.metadata["cali.caliper.version"]) == str
+    assert type(gf.metadata["cali.channel"]) == str


### PR DESCRIPTION
converts caliper metadata values into correct Python objects (e.g., int,
string, list)