### PR TITLE
Changes GitHub Action OS Image to Avoid Python Caching Issues

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@
 [run]
 parallel = True
 branch = True
+data_file = ./.coverage/coverage
 source = .
 omit =
      hatchet/tests/*

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -17,7 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
+        #       https://github.com/actions/setup-python/issues/162
+        os: [ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8, 3.9]
         hatchet-version: ["2022.2.0"]
 
@@ -50,13 +52,13 @@ jobs:
         cd $curr_dir
 
     - name: Show packages
-      run: |                                                                
-        python -m pip list                                                  
-                                                                            
-    - name: Prep tests                                                      
-      env:                                                                  
-        HATCHET_VERSION: ${{ matrix.hatchet-version }}                      
-        PYTHON_VERSION: ${{ matrix.python-version }}                        
+      run: |
+        python -m pip list
+
+    - name: Prep tests
+      env:
+        HATCHET_VERSION: ${{ matrix.hatchet-version }}
+        PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
         cp -r ./hatchet/tests ~
         test_dir="tests-$HATCHET_VERSION-$PYTHON_VERSION"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -113,6 +113,8 @@ jobs:
         PYTHONPATH=. coverage run $(which pytest)
 
     - name: "Upload coverage to Codecov"
-      uses: "codecov/codecov-action@v1"
+      uses: "codecov/codecov-action@v3"
       with:
         fail_ci_if_error: true
+        verbose: true
+        env_vars: OS,PYTHON

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       matrix:
         # TODO: add macos-latest
-        os: [ubuntu-latest]
+        # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
+        #       https://github.com/actions/setup-python/issues/162
+        os: [ubuntu-20.04]
         # TODO: add pypy2, pypy3
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         exclude:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -118,3 +118,4 @@ jobs:
         fail_ci_if_error: true
         verbose: true
         env_vars: OS,PYTHON
+        directory: ./.coverage

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -1006,7 +1006,7 @@ def timemory_json_data():
         ny = 10
         tol = 5.0e-2
         profl_arr = np.random.rand(nx, ny)
-        trace_arr = np.zeros([nx, ny], dtype=np.float)
+        trace_arr = np.zeros([nx, ny], dtype=np.float64)
         trace_arr[:, :] = profl_arr[:, :]
 
         # restrict the scope of the profiler


### PR DESCRIPTION
This PR allows us to avoid [this issue](https://github.com/actions/setup-python/issues/162) with the `setup-python` Action used in Hatchet's CI.

To do so, it simply changes the OS image for the CI from `ubuntu-latest` to `ubuntu-20.04`. When the linked issue is resolved, we can switch back to `ubuntu-latest`.