### PR TITLE
add clean to install to remove prior build artifacts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,6 @@ case *"$PWD"* in
         PYTHONPATH=$PWD:$PYTHONPATH
         ;;
 esac
-
+python setup.py clean --all
 python setup.py build_ext --inplace
 python hatchet/vis/static_fixer.py


### PR DESCRIPTION
Tiny update to the install script to remove build artifacts before rebuilding Cython modules. Especially useful when switching between major versions of Python.