### PR TITLE
Enables support for multi-indexed DataFrames in the Query Language

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -415,6 +415,7 @@ class GraphFrame:
         update_inc_cols=True,
         num_procs=mp.cpu_count(),
         rec_limit=1000,
+        multi_index_mode="off",
     ):
         """Filter the dataframe using a user-supplied function.
 
@@ -476,10 +477,15 @@ class GraphFrame:
         elif isinstance(filter_obj, (list, str)) or is_hatchet_query(filter_obj):
             # use a callpath query to apply the filter
             query = filter_obj
+            # If a raw Object-dialect query is provided (not already passed to ObjectQuery),
+            # create a new ObjectQuery object.
             if isinstance(filter_obj, list):
-                query = ObjectQuery(filter_obj)
+                query = ObjectQuery(filter_obj, multi_index_mode)
+            # If a raw String-dialect query is provided (not already passed to StringQuery),
+            # create a new StringQuery object.
             elif isinstance(filter_obj, str):
-                query = parse_string_dialect(filter_obj)
+                query = parse_string_dialect(filter_obj, multi_index_mode)
+            # If an old-style query is provided, extract the underlying new-style query.
             elif issubclass(type(filter_obj), AbstractQuery):
                 query = filter_obj._get_new_query()
             query_matches = self.query_engine.apply(query, self.graph, self.dataframe)

--- a/hatchet/query/errors.py
+++ b/hatchet/query/errors.py
@@ -18,3 +18,9 @@ class RedundantQueryFilterWarning(Warning):
 
 class BadNumberNaryQueryArgs(Exception):
     """Raised when a query filter does not have a valid syntax"""
+
+
+class MultiIndexModeMismatch(Exception):
+    """Raised when an ObjectQuery or StringQuery object
+    is set to use multi-indexed data, but no multi-indexed
+    data is provided"""

--- a/hatchet/query/object_dialect.py
+++ b/hatchet/query/object_dialect.py
@@ -6,6 +6,10 @@
 from numbers import Real
 import numpy as np
 import pandas as pd
+from pandas.api.types import (
+    is_numeric_dtype,
+    is_string_dtype,
+)
 import re
 import sys
 
@@ -150,7 +154,7 @@ def _process_predicate(attr_filter, multi_index_mode):
                 )
             if key not in df_row.columns:
                 return False
-            if df_row[key].apply(type).eq(str).all():
+            if is_string_dtype(df_row[key]):
                 if not isinstance(single_value, str):
                     raise InvalidQueryFilter(
                         "Value for attribute {} must be a string.".format(key)
@@ -163,7 +167,7 @@ def _process_predicate(attr_filter, multi_index_mode):
                     )
                 )
                 return _process_multi_index_mode(apply_ret, multi_index_mode)
-            if df_row[key].apply(type).eq(Real).all():
+            if is_numeric_dtype(df_row[key]):
                 if isinstance(
                     single_value, str
                 ) and single_value.lower().startswith(compops):

--- a/hatchet/query/object_dialect.py
+++ b/hatchet/query/object_dialect.py
@@ -13,19 +13,19 @@ from pandas.api.types import (
 import re
 import sys
 
-from .errors import (
-    InvalidQueryPath,
-    InvalidQueryFilter,
-    MultiIndexModeMismatch
-)
+from .errors import InvalidQueryPath, InvalidQueryFilter, MultiIndexModeMismatch
 from .query import Query
+
 
 def _process_multi_index_mode(apply_result, multi_index_mode):
     if multi_index_mode == "any":
         return apply_result.any()
     if multi_index_mode == "all":
         return apply_result.all()
-    raise ValueError("Multi-Index Mode for the Object-based dialect must be either 'any' or 'all'")
+    raise ValueError(
+        "Multi-Index Mode for the Object-based dialect must be either 'any' or 'all'"
+    )
+
 
 def _process_predicate(attr_filter, multi_index_mode):
     """Converts high-level API attribute filter to a lambda"""
@@ -159,29 +159,20 @@ def _process_predicate(attr_filter, multi_index_mode):
                     raise InvalidQueryFilter(
                         "Value for attribute {} must be a string.".format(key)
                     )
-                apply_ret = (
-                    df_row[key]
-                    .apply(
-                        lambda x: re.match(single_value + r"\Z", x)
-                        is not None
-                    )
+                apply_ret = df_row[key].apply(
+                    lambda x: re.match(single_value + r"\Z", x) is not None
                 )
                 return _process_multi_index_mode(apply_ret, multi_index_mode)
             if is_numeric_dtype(df_row[key]):
-                if isinstance(
-                    single_value, str
-                ) and single_value.lower().startswith(compops):
-                    apply_ret = (
-                        df_row[key]
-                        .apply(
-                            lambda x: eval("{} {}".format(x, single_value))
-                        )
+                if isinstance(single_value, str) and single_value.lower().startswith(
+                    compops
+                ):
+                    apply_ret = df_row[key].apply(
+                        lambda x: eval("{} {}".format(x, single_value))
                     )
                     return _process_multi_index_mode(apply_ret, multi_index_mode)
                 if isinstance(single_value, Real):
-                    apply_ret = (
-                        df_row[key].apply(lambda x: x == single_value).any()
-                    )
+                    apply_ret = df_row[key].apply(lambda x: x == single_value).any()
                     return _process_multi_index_mode(apply_ret, multi_index_mode)
                 raise InvalidQueryFilter(
                     "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
@@ -240,7 +231,9 @@ class ObjectQuery(Query):
             elif isinstance(qnode, tuple):
                 assert isinstance(qnode[1], dict)
                 if isinstance(qnode[0], str) or isinstance(qnode[0], int):
-                    self._add_node(qnode[0], _process_predicate(qnode[1], multi_index_mode))
+                    self._add_node(
+                        qnode[0], _process_predicate(qnode[1], multi_index_mode)
+                    )
                 else:
                     raise InvalidQueryPath(
                         "The first value of a tuple entry in a path must be either a string or integer."

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -88,7 +88,7 @@ class StringQuery(Query):
 
     """Class for representing and parsing queries using the String-based dialect."""
 
-    def __init__(self, cypher_query):
+    def __init__(self, cypher_query, multi_index_mode="off"):
         """Builds a new StringQuery object representing a query in the String-based dialect.
 
         Arguments:
@@ -98,6 +98,8 @@ class StringQuery(Query):
             super(StringQuery, self).__init__()
         else:
             super().__init__()
+        assert multi_index_mode in ["off", "all", "any"]
+        self.multi_index_mode = multi_index_mode
         model = None
         try:
             model = cypher_query_mm.model_from_str(cypher_query)
@@ -247,6 +249,13 @@ class StringQuery(Query):
         converted_subcond[2] = "not {}".format(converted_subcond[2])
         return converted_subcond
 
+    def _run_method_based_on_multi_idx_mode(self, method_name, obj):
+        real_method_name = method_name
+        if self.multi_index_mode != "off":
+            real_method_name = method_name + "_multi_idx"
+        method = eval("StringQuery.{}".format(real_method_name))
+        return method(self, obj)
+
     def _parse_single_cond(self, obj):
         """Top level function for parsing individual numeric or string predicates."""
         if self._is_str_cond(obj):
@@ -254,13 +263,13 @@ class StringQuery(Query):
         if self._is_num_cond(obj):
             return self._parse_num(obj)
         if cname(obj) == "NoneCond":
-            return self._parse_none(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_none", obj)
         if cname(obj) == "NotNoneCond":
-            return self._parse_not_none(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_not_none", obj)
         if cname(obj) == "LeafCond":
-            return self._parse_leaf(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_leaf", obj)
         if cname(obj) == "NotLeafCond":
-            return self._parse_not_leaf(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_not_leaf", obj)
         raise RuntimeError("Bad Single Condition")
 
     def _parse_none(self, obj):
@@ -286,6 +295,45 @@ class StringQuery(Query):
             None,
         ]
 
+    def _add_aggregation_call_to_multi_idx_predicate(self, predicate):
+        if self.multi_index_mode == "any":
+            return predicate + ".any()"
+        return predicate + ".all()"
+
+    def _parse_none_multi_idx(self, obj):
+        if obj.prop == "depth":
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth is None",
+                None
+            ]
+        if obj.prop == "node_id":
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid is None",
+                None,
+            ]
+        if self.multi_index_mode == "any":
+            return [
+                None,
+                obj.name,
+                "df_row['{}'].apply(lambda elem: elem is None).any()".format(obj.prop),
+                None
+            ]
+        # if self.multi_index_mode == "all":
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                "df_row['{}'].apply(lambda elem: elem is None)".format(
+                    obj.prop
+                )
+            ),
+            None
+        ]
+
     def _parse_not_none(self, obj):
         """Parses 'property IS NOT NONE'."""
         if obj.prop == "depth":
@@ -309,6 +357,32 @@ class StringQuery(Query):
             None,
         ]
 
+    def _parse_not_none_multi_idx(self, obj):
+        if obj.prop == "depth":
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth is not None",
+                None
+            ]
+        if obj.prop == "node_id":
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid is not None",
+                None,
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                "df_row['{}'].apply(lambda elem: elem is not None)".format(
+                    obj.prop
+                )
+            ),
+            None
+        ]
+
     def _parse_leaf(self, obj):
         """Parses 'node IS LEAF'."""
         return [
@@ -318,12 +392,28 @@ class StringQuery(Query):
             None,
         ]
 
+    def _parse_leaf_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            "len(df_row.index.get_level_values('node')[0].children) == 0",
+            None,
+        ]
+
     def _parse_not_leaf(self, obj):
         """Parses 'node IS NOT LEAF'."""
         return [
             None,
             obj.name,
             "len(df_row.name.children) > 0",
+            None,
+        ]
+
+    def _parse_not_leaf_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            "len(df_row.index.get_level_values('node')[0].children) > 0",
             None,
         ]
 
@@ -360,15 +450,15 @@ class StringQuery(Query):
         to the correct function.
         """
         if cname(obj) == "StringEq":
-            return self._parse_str_eq(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_str_eq", obj)
         if cname(obj) == "StringStartsWith":
-            return self._parse_str_starts_with(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_str_starts_with", obj)
         if cname(obj) == "StringEndsWith":
-            return self._parse_str_ends_with(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_str_ends_with", obj)
         if cname(obj) == "StringContains":
-            return self._parse_str_contains(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_str_contains", obj)
         if cname(obj) == "StringMatch":
-            return self._parse_str_match(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_str_match", obj)
         raise RuntimeError("Bad String Op Class")
 
     def _parse_str_eq(self, obj):
@@ -380,6 +470,18 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], str)".format(obj.prop),
         ]
 
+    def _parse_str_eq_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem == "{}")'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+        ]
+
     def _parse_str_starts_with(self, obj):
         """Processes string 'startswith' predicates."""
         return [
@@ -387,6 +489,18 @@ class StringQuery(Query):
             obj.name,
             'df_row["{}"].startswith("{}")'.format(obj.prop, obj.val),
             "isinstance(df_row['{}'], str)".format(obj.prop),
+        ]
+
+    def _parse_str_starts_with_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem.startswith("{}"))'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
         ]
 
     def _parse_str_ends_with(self, obj):
@@ -398,6 +512,18 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], str)".format(obj.prop),
         ]
 
+    def _parse_str_ends_with_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem.endswith("{}"))'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+        ]
+
     def _parse_str_contains(self, obj):
         """Processes string 'contains' predicates."""
         return [
@@ -405,6 +531,18 @@ class StringQuery(Query):
             obj.name,
             '"{}" in df_row["{}"]'.format(obj.val, obj.prop),
             "isinstance(df_row['{}'], str)".format(obj.prop),
+        ]
+
+    def _parse_str_contains_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: "{}" in elem)'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
         ]
 
     def _parse_str_match(self, obj):
@@ -416,28 +554,40 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], str)".format(obj.prop),
         ]
 
+    def _parse_str_match_multi_idx(self, obj):
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: re.match("{}", elem) is not None)'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+        ]
+
     def _parse_num(self, obj):
         """Function that redirects processing of numeric predicates
         to the correct function.
         """
         if cname(obj) == "NumEq":
-            return self._parse_num_eq(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_eq", obj)
         if cname(obj) == "NumLt":
-            return self._parse_num_lt(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_lt", obj)
         if cname(obj) == "NumGt":
-            return self._parse_num_gt(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_gt", obj)
         if cname(obj) == "NumLte":
-            return self._parse_num_lte(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_lte", obj)
         if cname(obj) == "NumGte":
-            return self._parse_num_gte(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_gte", obj)
         if cname(obj) == "NumNan":
-            return self._parse_num_nan(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_nan", obj)
         if cname(obj) == "NumNotNan":
-            return self._parse_num_not_nan(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_not_nan", obj)
         if cname(obj) == "NumInf":
-            return self._parse_num_inf(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_inf", obj)
         if cname(obj) == "NumNotInf":
-            return self._parse_num_not_inf(obj)
+            return self._run_method_based_on_multi_idx_mode("_parse_num_not_inf", obj)
         raise RuntimeError("Bad Number Op Class")
 
     def _parse_num_eq(self, obj):
@@ -506,6 +656,75 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], Real)".format(obj.prop),
         ]
 
+    def _parse_num_eq_multi_idx(self, obj):
+        if obj.prop == "depth":
+            if obj.val == -1:
+                return [
+                    None,
+                    obj.name,
+                    "len(df_row.index.get_level_values('node')[0].children) == 0",
+                    None,
+                ]
+            elif obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth == {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid == {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem == {})'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop)
+        ]
+
     def _parse_num_lt(self, obj):
         """Processes numeric less-than predicates."""
         if obj.prop == "depth":
@@ -563,6 +782,68 @@ class StringQuery(Query):
             obj.name,
             'df_row["{}"] < {}'.format(obj.prop, obj.val),
             "isinstance(df_row['{}'], Real)".format(obj.prop),
+        ]
+
+    def _parse_num_lt_multi_idx(self, obj):
+        if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth < {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid < {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem < {})'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop)
         ]
 
     def _parse_num_gt(self, obj):
@@ -624,6 +905,68 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], Real)".format(obj.prop),
         ]
 
+    def _parse_num_gt_multi_idx(self, obj):
+        if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth > {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid > {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem > {})'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+        ]
+
     def _parse_num_lte(self, obj):
         """Processes numeric less-than-or-equal-to predicates."""
         if obj.prop == "depth":
@@ -681,6 +1024,68 @@ class StringQuery(Query):
             obj.name,
             'df_row["{}"] <= {}'.format(obj.prop, obj.val),
             "isinstance(df_row['{}'], Real)".format(obj.prop),
+        ]
+
+    def _parse_num_lte_multi_idx(self, obj):
+        if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth <= {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be false.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "False",
+                    "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid <= {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem <= {})'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
         ]
 
     def _parse_num_gte(self, obj):
@@ -742,6 +1147,68 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], Real)".format(obj.prop),
         ]
 
+    def _parse_num_gte_multi_idx(self, obj):
+        if obj.prop == "depth":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'depth' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._depth >= {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            if obj.val < 0:
+                warnings.warn(
+                    """
+                    The 'node_id' property of a Node is strictly non-negative.
+                    This condition will always be true.
+                    The statement that triggered this warning is:
+                    {}
+                    """.format(
+                        obj
+                    ),
+                    RedundantQueryFilterWarning,
+                )
+                return [
+                    None,
+                    obj.name,
+                    "True",
+                    "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+                ]
+            return [
+                None,
+                obj.name,
+                "df_row.index.get_level_values('node')[0]._hatchet_nid >= {}".format(obj.val),
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'df_row["{}"].apply(lambda elem: elem >= {})'.format(
+                    obj.prop, obj.val
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+        ]
+
     def _parse_num_nan(self, obj):
         """Processes predicates that check for NaN."""
         if obj.prop == "depth":
@@ -763,6 +1230,32 @@ class StringQuery(Query):
             obj.name,
             'pd.isna(df_row["{}"])'.format(obj.prop),
             "isinstance(df_row['{}'], Real)".format(obj.prop),
+        ]
+
+    def _parse_num_nan_multi_idx(self, obj):
+        if obj.prop == "depth":
+            return [
+                None,
+                obj.name,
+                "pd.isna(df_row.index.get_level_values('node')[0]._depth)",
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            return [
+                None,
+                obj.name,
+                "pd.isna(df_row.index.get_level_values('node')[0]._hatchet_nid)",
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'pd.isna(df_row["{}"])'.format(
+                    obj.prop
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
         ]
 
     def _parse_num_not_nan(self, obj):
@@ -788,6 +1281,32 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], Real)".format(obj.prop),
         ]
 
+    def _parse_num_not_nan_multi_idx(self, obj):
+        if obj.prop == "depth":
+            return [
+                None,
+                obj.name,
+                "not pd.isna(df_row.index.get_level_values('node')[0]._depth)",
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            return [
+                None,
+                obj.name,
+                "not pd.isna(df_row.index.get_level_values('node')[0]._hatchet_nid)",
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'not pd.isna(df_row["{}"])'.format(
+                    obj.prop
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+        ]
+
     def _parse_num_inf(self, obj):
         """Processes predicates that check for Infinity."""
         if obj.prop == "depth":
@@ -811,6 +1330,32 @@ class StringQuery(Query):
             "isinstance(df_row['{}'], Real)".format(obj.prop),
         ]
 
+    def _parse_num_inf_multi_idx(self, obj):
+        if obj.prop == "depth":
+            return [
+                None,
+                obj.name,
+                "np.isinf(df_row.index.get_level_values('node')[0]._depth)",
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            return [
+                None,
+                obj.name,
+                "np.isinf(df_row.index.get_level_values('node')[0]._hatchet_nid)",
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'np.isinf(df_row["{}"])'.format(
+                    obj.prop
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+        ]
+
     def _parse_num_not_inf(self, obj):
         """Processes predicates that check for not-Infinity."""
         if obj.prop == "depth":
@@ -832,6 +1377,32 @@ class StringQuery(Query):
             obj.name,
             'not np.isinf(df_row["{}"])'.format(obj.prop),
             "isinstance(df_row['{}'], Real)".format(obj.prop),
+        ]
+
+    def _parse_num_not_inf_multi_idx(self, obj):
+        if obj.prop == "depth":
+            return [
+                None,
+                obj.name,
+                "not np.isinf(df_row.index.get_level_values('node')[0]._depth)",
+                "isinstance(df_row.index.get_level_values('node')[0]._depth, Real)",
+            ]
+        if obj.prop == "node_id":
+            return [
+                None,
+                obj.name,
+                "not np.isinf(df_row.index.get_level_values('node')[0]._hatchet_nid)",
+                "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
+            ]
+        return [
+            None,
+            obj.name,
+            self._add_aggregation_call_to_multi_idx_predicate(
+                'not np.isinf(df_row["{}"])'.format(
+                    obj.prop
+                )
+            ),
+            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
         ]
 
 

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -7,7 +7,7 @@ from numbers import Real
 import re
 import sys
 import pandas as pd  # noqa: F401
-from pandas.api.types import is_numeric_dtype, is_string_dtype # noqa: F401
+from pandas.api.types import is_numeric_dtype, is_string_dtype  # noqa: F401
 import numpy as np  # noqa: F401
 from textx import metamodel_from_str
 from textx.exceptions import TextXError
@@ -307,7 +307,7 @@ class StringQuery(Query):
                 None,
                 obj.name,
                 "df_row.index.get_level_values('node')[0]._depth is None",
-                None
+                None,
             ]
         if obj.prop == "node_id":
             return [
@@ -321,18 +321,16 @@ class StringQuery(Query):
                 None,
                 obj.name,
                 "df_row['{}'].apply(lambda elem: elem is None).any()".format(obj.prop),
-                None
+                None,
             ]
         # if self.multi_index_mode == "all":
         return [
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                "df_row['{}'].apply(lambda elem: elem is None)".format(
-                    obj.prop
-                )
+                "df_row['{}'].apply(lambda elem: elem is None)".format(obj.prop)
             ),
-            None
+            None,
         ]
 
     def _parse_not_none(self, obj):
@@ -364,7 +362,7 @@ class StringQuery(Query):
                 None,
                 obj.name,
                 "df_row.index.get_level_values('node')[0]._depth is not None",
-                None
+                None,
             ]
         if obj.prop == "node_id":
             return [
@@ -377,11 +375,9 @@ class StringQuery(Query):
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                "df_row['{}'].apply(lambda elem: elem is not None)".format(
-                    obj.prop
-                )
+                "df_row['{}'].apply(lambda elem: elem is not None)".format(obj.prop)
             ),
-            None
+            None,
         ]
 
     def _parse_leaf(self, obj):
@@ -453,7 +449,9 @@ class StringQuery(Query):
         if cname(obj) == "StringEq":
             return self._run_method_based_on_multi_idx_mode("_parse_str_eq", obj)
         if cname(obj) == "StringStartsWith":
-            return self._run_method_based_on_multi_idx_mode("_parse_str_starts_with", obj)
+            return self._run_method_based_on_multi_idx_mode(
+                "_parse_str_starts_with", obj
+            )
         if cname(obj) == "StringEndsWith":
             return self._run_method_based_on_multi_idx_mode("_parse_str_ends_with", obj)
         if cname(obj) == "StringContains":
@@ -712,18 +710,18 @@ class StringQuery(Query):
             return [
                 None,
                 obj.name,
-                "df_row.index.get_level_values('node')[0]._hatchet_nid == {}".format(obj.val),
+                "df_row.index.get_level_values('node')[0]._hatchet_nid == {}".format(
+                    obj.val
+                ),
                 "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
             ]
         return [
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'df_row["{}"].apply(lambda elem: elem == {})'.format(
-                    obj.prop, obj.val
-                )
+                'df_row["{}"].apply(lambda elem: elem == {})'.format(obj.prop, obj.val)
             ),
-            "is_numeric_dtype(df_row['{}'])".format(obj.prop)
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_lt(self, obj):
@@ -833,18 +831,18 @@ class StringQuery(Query):
             return [
                 None,
                 obj.name,
-                "df_row.index.get_level_values('node')[0]._hatchet_nid < {}".format(obj.val),
+                "df_row.index.get_level_values('node')[0]._hatchet_nid < {}".format(
+                    obj.val
+                ),
                 "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
             ]
         return [
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'df_row["{}"].apply(lambda elem: elem < {})'.format(
-                    obj.prop, obj.val
-                )
+                'df_row["{}"].apply(lambda elem: elem < {})'.format(obj.prop, obj.val)
             ),
-            "is_numeric_dtype(df_row['{}'])".format(obj.prop)
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_gt(self, obj):
@@ -954,16 +952,16 @@ class StringQuery(Query):
             return [
                 None,
                 obj.name,
-                "df_row.index.get_level_values('node')[0]._hatchet_nid > {}".format(obj.val),
+                "df_row.index.get_level_values('node')[0]._hatchet_nid > {}".format(
+                    obj.val
+                ),
                 "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
             ]
         return [
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'df_row["{}"].apply(lambda elem: elem > {})'.format(
-                    obj.prop, obj.val
-                )
+                'df_row["{}"].apply(lambda elem: elem > {})'.format(obj.prop, obj.val)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
@@ -1075,16 +1073,16 @@ class StringQuery(Query):
             return [
                 None,
                 obj.name,
-                "df_row.index.get_level_values('node')[0]._hatchet_nid <= {}".format(obj.val),
+                "df_row.index.get_level_values('node')[0]._hatchet_nid <= {}".format(
+                    obj.val
+                ),
                 "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
             ]
         return [
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'df_row["{}"].apply(lambda elem: elem <= {})'.format(
-                    obj.prop, obj.val
-                )
+                'df_row["{}"].apply(lambda elem: elem <= {})'.format(obj.prop, obj.val)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
@@ -1196,16 +1194,16 @@ class StringQuery(Query):
             return [
                 None,
                 obj.name,
-                "df_row.index.get_level_values('node')[0]._hatchet_nid >= {}".format(obj.val),
+                "df_row.index.get_level_values('node')[0]._hatchet_nid >= {}".format(
+                    obj.val
+                ),
                 "isinstance(df_row.index.get_level_values('node')[0]._hatchet_nid, Real)",
             ]
         return [
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'df_row["{}"].apply(lambda elem: elem >= {})'.format(
-                    obj.prop, obj.val
-                )
+                'df_row["{}"].apply(lambda elem: elem >= {})'.format(obj.prop, obj.val)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
@@ -1252,9 +1250,7 @@ class StringQuery(Query):
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'pd.isna(df_row["{}"])'.format(
-                    obj.prop
-                )
+                'pd.isna(df_row["{}"])'.format(obj.prop)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
@@ -1301,9 +1297,7 @@ class StringQuery(Query):
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'not pd.isna(df_row["{}"])'.format(
-                    obj.prop
-                )
+                'not pd.isna(df_row["{}"])'.format(obj.prop)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
@@ -1350,9 +1344,7 @@ class StringQuery(Query):
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'np.isinf(df_row["{}"])'.format(
-                    obj.prop
-                )
+                'np.isinf(df_row["{}"])'.format(obj.prop)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
@@ -1399,9 +1391,7 @@ class StringQuery(Query):
             None,
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
-                'not np.isinf(df_row["{}"])'.format(
-                    obj.prop
-                )
+                'not np.isinf(df_row["{}"])'.format(obj.prop)
             ),
             "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -7,6 +7,7 @@ from numbers import Real
 import re
 import sys
 import pandas as pd  # noqa: F401
+from pandas.api.types import is_numeric_dtype, is_string_dtype # noqa: F401
 import numpy as np  # noqa: F401
 from textx import metamodel_from_str
 from textx.exceptions import TextXError
@@ -479,7 +480,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+            "is_string_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_str_starts_with(self, obj):
@@ -500,7 +501,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+            "is_string_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_str_ends_with(self, obj):
@@ -521,7 +522,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+            "is_string_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_str_contains(self, obj):
@@ -542,7 +543,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+            "is_string_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_str_match(self, obj):
@@ -563,7 +564,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(str).all()".format(obj.prop),
+            "is_string_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num(self, obj):
@@ -722,7 +723,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop)
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop)
         ]
 
     def _parse_num_lt(self, obj):
@@ -843,7 +844,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop)
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop)
         ]
 
     def _parse_num_gt(self, obj):
@@ -964,7 +965,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_lte(self, obj):
@@ -1085,7 +1086,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_gte(self, obj):
@@ -1206,7 +1207,7 @@ class StringQuery(Query):
                     obj.prop, obj.val
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_nan(self, obj):
@@ -1255,7 +1256,7 @@ class StringQuery(Query):
                     obj.prop
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_not_nan(self, obj):
@@ -1304,7 +1305,7 @@ class StringQuery(Query):
                     obj.prop
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_inf(self, obj):
@@ -1353,7 +1354,7 @@ class StringQuery(Query):
                     obj.prop
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
     def _parse_num_not_inf(self, obj):
@@ -1402,11 +1403,11 @@ class StringQuery(Query):
                     obj.prop
                 )
             ),
-            "df_row['{}'].apply(type).eq(Real).all()".format(obj.prop),
+            "is_numeric_dtype(df_row['{}'])".format(obj.prop),
         ]
 
 
-def parse_string_dialect(query_str):
+def parse_string_dialect(query_str, multi_index_mode="off"):
     """Parse all types of String-based queries, including multi-queries that leverage
     the curly brace delimiters.
 
@@ -1428,7 +1429,7 @@ def parse_string_dialect(query_str):
     if num_curly_brace_elems == 0:
         if sys.version_info[0] == 2:
             query_str = query_str.decode("utf-8")
-        return StringQuery(query_str)
+        return StringQuery(query_str, multi_index_mode)
     # Create an iterator over the curly brace-delimited regions
     curly_brace_iter = re.finditer(r"\{(.*?)\}", query_str)
     # Will store curly brace-delimited regions in the WHERE clause
@@ -1517,14 +1518,14 @@ def parse_string_dialect(query_str):
                 query1 = "MATCH {} WHERE {}".format(match_comp, condition_list[i])
                 if sys.version_info[0] == 2:
                     query1 = query1.decode("utf-8")
-                full_query = StringQuery(query1)
+                full_query = StringQuery(query1, multi_index_mode)
             # Get the next query as a CypherQuery where
             # the MATCH clause is the shared match clause and the WHERE clause is the
             # next curly brace-delimited region
             next_query = "MATCH {} WHERE {}".format(match_comp, condition_list[i + 1])
             if sys.version_info[0] == 2:
                 next_query = next_query.decode("utf-8")
-            next_query = StringQuery(next_query)
+            next_query = StringQuery(next_query, multi_index_mode)
             # Add the next query to the full query using the compound operator
             # currently being considered
             if op == "AND":

--- a/hatchet/tests/query_compat.py
+++ b/hatchet/tests/query_compat.py
@@ -27,6 +27,7 @@ from hatchet.query import (
 
 def test_apply_indices(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+    gf.drop_index_levels()
     main = gf.graph.roots[0].children[0]
     path = [
         {"name": "[0-9]*:?MPI_.*"},
@@ -118,6 +119,7 @@ def test_high_level_hatchet_nid(mock_graph_literal):
 
 def test_high_level_depth_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+    gf.drop_index_levels()
     root = gf.graph.roots[0]
 
     query = QueryMatcher([("*", {"depth": "<= 2"})])
@@ -143,6 +145,7 @@ def test_high_level_depth_index_levels(calc_pi_hpct_db):
 
 def test_high_level_node_id_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+    gf.drop_index_levels()
     root = gf.graph.roots[0]
 
     query = QueryMatcher([("*", {"node_id": "<= 2"})])


### PR DESCRIPTION
## Summary

Currently, the Object-based dialect and String-based dialect of the Query Language cannot handle GraphFrames containing a DataFrame with a multi-index (e.g., when you have rank and thread info).

This PR adds support for that type of data to the Object-based Dialect and String-based Dialect. This support comes in the form of a new `multi_index_mode` argument to the `ObjectQuery` constructor, the `StringQuery` constructor, the `parse_string_dialect` function, and the `GraphFrame.filter` function. This argument can have one of three values:
* `"off"` (default): query will be applied under the assumption that the `DataFrame` does not have a `MultiIndex` (i.e., the currently behavior of the QL)
* `"all"`: when applying a predicate to a particular node's data in the `DataFrame`, all rows associated with the node must satisfy the predicate
* `"any"`: when applying a predicate to a particular node's data in the `DataFrame`, at least one row associate with the node must satisfy the predicate

The implementation of these three modes is performed within the `ObjectQuery` and `StringQuery` classes. In these classes, the translation of predicates from dialects to the "base" syntax (represented by the `Query` class) will differ depending on the value of `multi_index_mode`. Since the implementation of this functionality is in `ObjectQuery` and `StringQuery`, the `multi_index_mode` arguments to `parse_string_dialect` and `GraphFrame.filter` are simply passed through to the correct class.

Finally, one important thing to note is that this functionality is **ONLY** implemented for new-style queries (as defined in PR #72). Old-style queries (e.g., using the `QueryMatcher` class) do not support this behavior.

## What's Left to Do?

In short, all that's left in this PR is unit testing. I still need to implement tests in `test/query.py` and confirm that everything is working correctly.