### PR TITLE
caliperreader: fix duplicate dataframe rows

### DIFF
--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -113,7 +113,8 @@ class CaliperNativeReader:
                 self.metric_cols.append(col)
 
         df_metrics = pd.DataFrame.from_dict(data=all_metrics)
-        return df_metrics
+        df_new = df_metrics.groupby(df_metrics["nid"]).aggregate("first").reset_index()
+        return df_new
 
     def create_graph(self, ctx="path"):
         list_roots = []


### PR DESCRIPTION
root nids were mapping to multiple series of metrics, this merges the metrics for the same node into a single dataframe row