### PR TITLE
Adds hatchet.query as a subpackage in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "hatchet",
         "hatchet.readers",
         "hatchet.writers",
+        "hatchet.query",
         "hatchet.util",
         "hatchet.external",
         "hatchet.tests",


### PR DESCRIPTION
Since `hatchet.query` is now a package (i.e., a directory) instead of a module (i.e., a `.py` script), we need to add it to the `packages` field of `setup.py`. This PR does this.