### PR TITLE
Adds Cython to the build-system requires list in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
+    "Cython",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
After merging #85, Hatchet was failing to build with a PEP 517-compliant builder (e.g., PyPA build and pip). The reason for this is that Cython was not included in the `build-system.requires` list in `pyproject.toml`. Under PEP 517 (and it's follow-up PEPs), these builders build Python packages in a virtual environment. This environment is initialized with the packages specified in the `build-system.requires` list in `pyproject.toml`. Since Cython wasn't specified in that list, Cython wasn't available when building Hatchet, causing PyPA build and pip to fail.

This PR fixes this bug by adding Cython to that list.