### PR TITLE
Adds support for optional additional string attributes

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -126,7 +126,9 @@ class GraphFrame:
         return CaliperReader(filename_or_stream, query).read()
 
     @staticmethod
-    def from_caliperreader(filename_or_caliperreader, native=False, string_attributes=[]):
+    def from_caliperreader(
+        filename_or_caliperreader, native=False, string_attributes=[]
+    ):
         """Read in a native Caliper `cali` file using Caliper's python reader.
 
         Args:
@@ -139,7 +141,9 @@ class GraphFrame:
         # import this lazily to avoid circular dependencies
         from .readers.caliper_native_reader import CaliperNativeReader
 
-        return CaliperNativeReader(filename_or_caliperreader, native, string_attributes).read()
+        return CaliperNativeReader(
+            filename_or_caliperreader, native, string_attributes
+        ).read()
 
     @staticmethod
     def from_spotdb(db_key, list_of_ids=None):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -133,8 +133,8 @@ class GraphFrame:
             filename_or_caliperreader (str or CaliperReader): name of a Caliper
                 output file in `.cali` format, or a CaliperReader object
             native (bool): use native or user-readable metric names (default)
-            string_attributes (str or list): Adds existing string attributes
-                from within the caliper file to the dataframe
+            string_attributes (str or list, optional): Adds existing string
+                attributes from within the caliper file to the dataframe
         """
         # import this lazily to avoid circular dependencies
         from .readers.caliper_native_reader import CaliperNativeReader

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -126,18 +126,20 @@ class GraphFrame:
         return CaliperReader(filename_or_stream, query).read()
 
     @staticmethod
-    def from_caliperreader(filename_or_caliperreader, native=False):
+    def from_caliperreader(filename_or_caliperreader, native=False, string_attributes=[]):
         """Read in a native Caliper `cali` file using Caliper's python reader.
 
         Args:
             filename_or_caliperreader (str or CaliperReader): name of a Caliper
                 output file in `.cali` format, or a CaliperReader object
             native (bool): use native or user-readable metric names (default)
+            string_attributes (str or list): Adds existing string attributes
+                from within the caliper file to the dataframe
         """
         # import this lazily to avoid circular dependencies
         from .readers.caliper_native_reader import CaliperNativeReader
 
-        return CaliperNativeReader(filename_or_caliperreader, native).read()
+        return CaliperNativeReader(filename_or_caliperreader, native, string_attributes).read()
 
     @staticmethod
     def from_spotdb(db_key, list_of_ids=None):


### PR DESCRIPTION
Adds support for optional additional string attributes

- Currently, only numerical and some specific string attributes from caliper files are added to the Hatchet dataframe
- This PR allows the user to provide an optional string or a list of string-based attributes that might exist in caliper files, which are then added to the dataframe
- The default behavior is not changed