### PR TITLE
Hotfix: fixes bug where Roundtrip is not distributed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ recursive-include hatchet/vis/scripts *
 recursive-include hatchet/vis/static *
 recursive-include hatchet/vis/templates *
 recursive-include hatchet/vis/styles *
+recursive-include hatchet/external/roundtrip *


### PR DESCRIPTION
Thanks to @vanessalama09, we discovered a bug that causes Hatchet's built-in Roundtrip to not be installed. This hotfix adds the `hatchet/external/roundtrip` directory to `MANIFEST.in` to fix this.