### PR TITLE
Deprecate Python2 CI coverage, fix Python3 CI

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -16,7 +16,7 @@ jobs:
 
   build_wheels_linux_3:
     name: Build wheels for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -69,7 +69,7 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -90,7 +90,7 @@ jobs:
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
       - build_sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v3
@@ -111,7 +111,7 @@ jobs:
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
       - build_sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -16,7 +16,7 @@ jobs:
 
   build_wheels_linux_3:
     name: Build wheels for Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -29,23 +29,6 @@ jobs:
         env:
           CIBW_SKIP: pp* *musllinux*
           CIBW_ARCHS_LINUX: auto aarch64 ppc64le
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
-  build_wheels_linux_27:
-    name: Build wheels for Python 2.7 on Linux
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-
-      # Neeed to use cibuildwheel 1 for Python 2.7
-      - uses: pypa/cibuildwheel@v1.12.0
-        env:
-          CIBW_SKIP: pp*
-          CIBW_ARCHS_LINUX: auto
-          CIBW_PROJECT_REQUIRES_PYTHON: "~=2.7"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -84,25 +67,9 @@ jobs:
   #       with:
   #         path: ./wheelhouse/*.whl
 
-  # build_wheels_macos_27:
-  #   name: Build wheels for Python 2.7 on macOS
-  #   runs-on: macos-12
-  #   steps:
-  #     - uses: actions/checkout@v3
-
-  #     # Neeed to use cibuildwheel 1 for Python 2.7
-  #     - uses: pypa/cibuildwheel@v1.12.0
-  #       env:
-  #         CIBW_SKIP: pp*
-  #         CIBW_BUILD: cp27-macosx_x86_64
-
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         path: ./wheelhouse/*.whl
-
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -122,9 +89,8 @@ jobs:
       - build_wheels_linux_27
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
-        # - build_wheels_macos_27
       - build_sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v3
@@ -144,9 +110,8 @@ jobs:
       - build_wheels_linux_27
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
-        # - build_wheels_macos_27
       - build_sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
         #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8, 3.9]
         hatchet-version: ["2022.2.0"]
 

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
         #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
         hatchet-version: ["2022.2.0"]
 
@@ -38,7 +38,6 @@ jobs:
         python -m pip install --upgrade pip pytest
 
     - name: Build Python 3 dependencies
-      if: ${{ matrix.python-version != 2.7 }}
       run: |
         python -m pip install tables
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -89,13 +89,13 @@ jobs:
         echo -e "PWD:${PWD}"
         which cali-query
 
-    - name: Build Timemory
-      if: ${{ matrix.python-version <= 3.6 }}
+    - name: Build Timemory for Python 3.6
+      if: ${{ matrix.python-version == 3.6 }}
       run: |
         python -m pip install --upgrade scikit-build
         # python -m pip install --upgrade --no-cache-dir --no-deps -v --pre timemory --install-option=--disable-{c,gotcha,tools}
         python -m pip install --upgrade --no-cache-dir --no-deps -v timemory==3.2.0.dev4 --install-option=--disable-{c,gotcha,tools}
-        
+
     - name: Test Caliper and Timemory Support with pytest
       run: |
         PYTHONPATH=. coverage run $(which pytest)

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -100,10 +100,10 @@ jobs:
       run: |
         PYTHONPATH=. coverage run $(which pytest)
 
-    - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # @v2.1.0
-      with:
-        fail_ci_if_error: true
-        verbose: true
-        env_vars: OS,PYTHON
-        directory: ./.coverage
+#    - name: "Upload coverage to Codecov"
+#      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # @v2.1.0
+#      with:
+#        fail_ci_if_error: true
+#        verbose: true
+#        env_vars: OS,PYTHON
+#        directory: ./.coverage

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         #       https://github.com/actions/setup-python/issues/162
         os: [ubuntu-20.04]
         # TODO: add pypy2, pypy3
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         exclude:
           - os: macos-latest
             python-version: [3.5, 3.6]
@@ -29,17 +29,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install Python2.7 dependencies
-      if: ${{ matrix.python-version == 2.7 }}
-      run: |
-        python -m pip install --upgrade pytest numexpr==2.7.3
-        pip install -r requirements.txt
-        # Optional Dependency for HDF Checkpointing
-        pip install tables
-        python setup.py install
-        python setup.py build_ext --inplace
-        python -m pip list
 
     - name: Install Python3 dependencies
       if: ${{ matrix.python-version != 2.7 }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,11 +15,14 @@ jobs:
         # TODO: add macos-latest
         # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
         #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-20.04]
         # TODO: add pypy2, pypy3
-        python-version: [3.7, 3.8]
-        #python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         exclude:
+          - os: ubuntu-latest
+            python-version: [3.5, 3.6]
+          - os: ubuntu-20.04
+            python-version: [3.7, 3.8]
           - os: macos-latest
             python-version: [3.5, 3.6]
 
@@ -96,7 +99,7 @@ jobs:
         python -m pip install --upgrade scikit-build
         # python -m pip install --upgrade --no-cache-dir --no-deps -v --pre timemory --install-option=--disable-{c,gotcha,tools}
         python -m pip install --upgrade --no-cache-dir --no-deps -v timemory==3.2.0.dev4 --install-option=--disable-{c,gotcha,tools}
-
+        
     - name: Test Caliper and Timemory Support with pytest
       run: |
         PYTHONPATH=. coverage run $(which pytest)

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,14 +15,10 @@ jobs:
         # TODO: add macos-latest
         # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
         #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-latest, ubuntu-20.04]
+        os: [ubuntu-20.04]
         # TODO: add pypy2, pypy3
         python-version: [3.5, 3.6, 3.7, 3.8]
         exclude:
-          - os: ubuntu-latest
-            python-version: [3.5, 3.6]
-          - os: ubuntu-20.04
-            python-version: [3.7, 3.8]
           - os: macos-latest
             python-version: [3.5, 3.6]
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,8 @@ jobs:
         #       https://github.com/actions/setup-python/issues/162
         os: [ubuntu-latest]
         # TODO: add pypy2, pypy3
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
+        #python-version: [3.5, 3.6, 3.7, 3.8]
         exclude:
           - os: macos-latest
             python-version: [3.5, 3.6]

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
         # TODO: add macos-latest
         # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
         #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         # TODO: add pypy2, pypy3
         python-version: [3.5, 3.6, 3.7, 3.8]
         exclude:
@@ -31,7 +31,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python3 dependencies
-      if: ${{ matrix.python-version != 2.7 }}
       run: |
         python -m pip install --upgrade pip pytest
         pip install -r requirements.txt
@@ -91,7 +90,7 @@ jobs:
         which cali-query
 
     - name: Build Timemory
-      if: ${{ matrix.python-version >= 3.6 }}
+      if: ${{ matrix.python-version <= 3.6 }}
       run: |
         python -m pip install --upgrade scikit-build
         # python -m pip install --upgrade --no-cache-dir --no-deps -v --pre timemory --install-option=--disable-{c,gotcha,tools}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -100,10 +100,11 @@ jobs:
       run: |
         PYTHONPATH=. coverage run $(which pytest)
 
-#    - name: "Upload coverage to Codecov"
-#      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # @v2.1.0
-#      with:
-#        fail_ci_if_error: true
-#        verbose: true
-#        env_vars: OS,PYTHON
-#        directory: ./.coverage
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # @v2.1.0
+      if: ${{ matrix.python-version >= 3.7 }}
+      with:
+        fail_ci_if_error: true
+        verbose: true
+        env_vars: OS,PYTHON
+        directory: ./.coverage

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -5,6 +5,7 @@
 
 
 import pandas as pd
+import numpy as np
 import os
 
 import caliperreader as cr
@@ -349,6 +350,7 @@ class CaliperNativeReader:
                 default_metric_dict[list(self.record_data_cols)[idx]] = 0
             else:
                 default_metric_dict[list(self.record_data_cols)[idx]] = None
+        default_metric_dict["nid"] = np.nan
 
         # create a list of dicts, one dict for each missing row
         missing_nodes = []
@@ -380,7 +382,6 @@ class CaliperNativeReader:
 
         df_missing = pd.DataFrame.from_dict(data=missing_nodes)
         df_metrics = pd.concat([df_fixed_data, df_missing], sort=False)
-        df_metrics["nid"] = df_metrics["nid"].astype(pd.Int64Dtype())
 
         # rename columns to user-readable metric names (i.e., aliases)
         if not self.use_native_metric_names:
@@ -441,6 +442,7 @@ class CaliperNativeReader:
         with self.timer.phase("data frame"):
             # merge the metrics and node dataframes on the nid column
             dataframe = pd.merge(df_metrics, self.df_nodes, on="nid")
+            dataframe["nid"] = dataframe["nid"].astype(pd.Int64Dtype())
 
             # set the index to be a MultiIndex
             indices = ["node"]

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -349,7 +349,6 @@ class CaliperNativeReader:
                 default_metric_dict[list(self.record_data_cols)[idx]] = 0
             else:
                 default_metric_dict[list(self.record_data_cols)[idx]] = None
-        default_metric_dict["nid"] = -1
 
         # create a list of dicts, one dict for each missing row
         missing_nodes = []
@@ -381,6 +380,7 @@ class CaliperNativeReader:
 
         df_missing = pd.DataFrame.from_dict(data=missing_nodes)
         df_metrics = pd.concat([df_fixed_data, df_missing], sort=False)
+        df_metrics["nid"] = df_metrics["nid"].astype(pd.Int64Dtype())
 
         # rename columns to user-readable metric names (i.e., aliases)
         if not self.use_native_metric_names:

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -349,7 +349,8 @@ class CaliperNativeReader:
                 default_metric_dict[list(self.record_data_cols)[idx]] = 0
             else:
                 default_metric_dict[list(self.record_data_cols)[idx]] = None
-
+        default_metric_dict["nid"] = -1
+        
         # create a list of dicts, one dict for each missing row
         missing_nodes = []
         for iteridx, row in self.df_nodes.iterrows():

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -350,7 +350,7 @@ class CaliperNativeReader:
             else:
                 default_metric_dict[list(self.record_data_cols)[idx]] = None
         default_metric_dict["nid"] = -1
-        
+
         # create a list of dicts, one dict for each missing row
         missing_nodes = []
         for iteridx, row in self.df_nodes.iterrows():

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -5,6 +5,7 @@
 
 import subprocess
 import numpy as np
+import pandas as pd
 
 import pytest
 import sys
@@ -224,7 +225,7 @@ def test_graphframe_native_lulesh_from_file(lulesh_caliper_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == np.int64
+            assert gf.dataframe[col].dtype == pd.Int64Dtype()
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 
@@ -250,7 +251,7 @@ def test_graphframe_native_lulesh_from_caliperreader(lulesh_caliper_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == np.int64
+            assert gf.dataframe[col].dtype == pd.Int64Dtype()
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     keywords="",
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
+    python_requires=">=3.5",
     packages=[
         "hatchet",
         "hatchet.readers",


### PR DESCRIPTION
Removing all python 2 references and moving to ubuntu-latest.