### PR TITLE
Adds support for tree annotations with coloring and min, max attributes

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -194,7 +194,7 @@ class ConsoleRenderer:
             + "Legend"
             + self.colors.end
             + " (Metric: "
-            + self.primary_metric
+            + str(self.primary_metric)
             + " Min: {:.2f}".format(self.min_metric)
             + " Max: {:.2f}".format(self.max_metric)
             + ")\n"

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -263,7 +263,7 @@ class ConsoleRenderer:
                     metric_str += " {}".format(annotation_content)
 
             if isinstance(dataframe.columns, pd.MultiIndex):
-                node_name = dataframe.loc[df_index, ("", self.name)]
+                node_name = dataframe.loc[df_index, (self.name, "")]
             else:
                 node_name = dataframe.loc[df_index, self.name]
             if self.expand is False:

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -275,30 +275,24 @@ class ConsoleRenderer:
                 self._ansi_color_for_name(node_name) + node_name + self.colors.end
             )
 
-            left_or_right = 0
-            if self.primary_metric in dataframe and np.isnan(dataframe.loc[df_index, self.primary_metric]):
-                left_or_right = 1
-            elif self.second_metric in dataframe and np.isnan(dataframe.loc[df_index, self.second_metric]):
-                left_or_right = 2
-
             # 0 is "", 1 is "L", and 2 is "R"
             if "_missing_node" in dataframe.columns:
                 left_or_right = dataframe.loc[df_index, "_missing_node"]
-            if left_or_right == 0:
-                lr_decorator = u""
-            elif left_or_right == 1:
-                lr_decorator = u" {c.left}{decorator}{c.end}".format(
-                    decorator=self.lr_arrows["◀"], c=self.colors
-                )
-            elif left_or_right == 2:
-                lr_decorator = u" {c.right}{decorator}{c.end}".format(
-                    decorator=self.lr_arrows["▶"], c=self.colors
-                )
+                if left_or_right == 0:
+                    lr_decorator = u""
+                elif left_or_right == 1:
+                    lr_decorator = u" {c.left}{decorator}{c.end}".format(
+                        decorator=self.lr_arrows["◀"], c=self.colors
+                    )
+                elif left_or_right == 2:
+                    lr_decorator = u" {c.right}{decorator}{c.end}".format(
+                        decorator=self.lr_arrows["▶"], c=self.colors
+                    )
 
             result = u"{indent}{metric_str} {name_str}".format(
                 indent=indent, metric_str=metric_str, name_str=name_str
             )
-            if left_or_right > 0:
+            if "_missing_node" in dataframe.columns:
                 result += lr_decorator
             if self.context in dataframe.columns:
                 result += u" {c.faint}{context}{c.end}\n".format(

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -78,16 +78,18 @@ class ConsoleRenderer:
 
             if self.annotation_column and self.colormap_annotations:
                 self.colors_annotations = self.colors_enabled()
-                if isinstance(self.colormap_annotations, str):
-                    self.colors_annotations.colormap = ColorMaps().get_colors(
-                        self.colormap_annotations, False
+                if isinstance(self.colormap_annotations, (str, list)):
+                    if isinstance(self.colormap_annotations, str):
+                        self.colors_annotations.colormap = ColorMaps().get_colors(
+                            self.colormap_annotations, False
+                        )
+                    elif isinstance(self.colormap_annotations, list):
+                        self.colors_annotations.colormap = self.colormap_annotations
+                    self.colors_annotations_mapping = sorted(
+                        list(dataframe[self.annotation_column].apply(str).unique())
                     )
-                elif isinstance(self.colormap_annotations, list):
-                    self.colors_annotations.colormap = self.colormap_annotations
-
-                self.colors_annotations_mapping = sorted(
-                    list(dataframe[self.annotation_column].apply(str).unique())
-                )
+                elif isinstance(self.colormap_annotations, dict):
+                    self.colors_annotations_mapping = self.colormap_annotations
         else:
             self.colors = self.colors_disabled
 
@@ -248,10 +250,12 @@ class ConsoleRenderer:
                     dataframe.loc[df_index, self.annotation_column]
                 )
                 if self.colormap_annotations:
-                    color_annotation = self.colors_annotations.colormap[
-                        self.colors_annotations_mapping.index(annotation_content) % len(self.colors_annotations.colormap)]
-                    metric_str += color_annotation
-                    metric_str += " {}".format(annotation_content)
+                    if isinstance(self.colormap_annotations, dict):
+                        color_annotation = self.colors_annotations_mapping[annotation_content]
+                    else:
+                        color_annotation = self.colors_annotations.colormap[
+                            self.colors_annotations_mapping.index(annotation_content) % len(self.colors_annotations.colormap)]
+                    metric_str += " {}{}".format(color_annotation,annotation_content)
                     metric_str += self.colors_annotations.end
                 else:
                     metric_str += " {}".format(annotation_content)

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -253,13 +253,17 @@ class ConsoleRenderer:
                 )
                 if self.colormap_annotations:
                     if isinstance(self.colormap_annotations, dict):
-                        color_annotation = self.colors_annotations_mapping[annotation_content]
+                        color_annotation = self.colors_annotations_mapping[
+                            annotation_content
+                        ]
                     else:
                         color_annotation = self.colors_annotations.colormap[
-                            self.colors_annotations_mapping.index(annotation_content) % len(self.colors_annotations.colormap)]
+                            self.colors_annotations_mapping.index(annotation_content)
+                            % len(self.colors_annotations.colormap)
+                        ]
                     metric_str += " [{}".format(color_annotation)
                     metric_str += "{}".format(annotation_content)
-                    metric_str +="{}]".format(self.colors_annotations.end)
+                    metric_str += "{}]".format(self.colors_annotations.end)
                 else:
                     metric_str += " [{}]".format(annotation_content)
 

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -56,6 +56,7 @@ class ConsoleRenderer:
             return result
 
         self.metric_columns = kwargs["metric_column"]
+        self.annotation_column = kwargs["annotation_column"]
         self.precision = kwargs["precision"]
         self.name = kwargs["name_column"]
         self.expand = kwargs["expand_name"]
@@ -76,7 +77,7 @@ class ConsoleRenderer:
         else:
             self.colors = self.colors_disabled
 
-        if isinstance(self.metric_columns, str):
+        if isinstance(self.metric_columns, (str, tuple)):
             self.primary_metric = self.metric_columns
             self.second_metric = None
         elif isinstance(self.metric_columns, list):
@@ -175,7 +176,7 @@ class ConsoleRenderer:
             + "Legend"
             + self.colors.end
             + " (Metric: "
-            + self.primary_metric
+            + str(self.primary_metric)
             + " Min: {:.2f}".format(self.min_metric)
             + " Max: {:.2f}".format(self.max_metric)
             + ")\n"
@@ -228,7 +229,15 @@ class ConsoleRenderer:
                     c=self.colors,
                 )
 
-            node_name = dataframe.loc[df_index, self.name]
+            if self.annotation_column is not None:
+                metric_str += " {}".format(
+                    dataframe.loc[df_index, self.annotation_column]
+                )
+
+            if isinstance(dataframe.columns, pd.MultiIndex):
+                node_name = dataframe.loc[df_index, ("", self.name)]
+            else:
+                node_name = dataframe.loc[df_index, self.name]
             if self.expand is False:
                 if len(node_name) > 39:
                     node_name = (

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -257,10 +257,11 @@ class ConsoleRenderer:
                     else:
                         color_annotation = self.colors_annotations.colormap[
                             self.colors_annotations_mapping.index(annotation_content) % len(self.colors_annotations.colormap)]
-                    metric_str += " {}{}".format(color_annotation,annotation_content)
-                    metric_str += self.colors_annotations.end
+                    metric_str += " [{}".format(color_annotation)
+                    metric_str += "{}".format(annotation_content)
+                    metric_str +="{}]".format(self.colors_annotations.end)
                 else:
-                    metric_str += " {}".format(annotation_content)
+                    metric_str += " [{}]".format(annotation_content)
 
             if isinstance(dataframe.columns, pd.MultiIndex):
                 node_name = dataframe.loc[df_index, (self.name, "")]

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -95,7 +95,7 @@ class ConsoleRenderer:
         else:
             self.colors = self.colors_disabled
 
-        if isinstance(self.metric_columns, (str, tuple)):
+        if isinstance(self.metric_columns, str):
             self.primary_metric = self.metric_columns
             self.second_metric = None
         elif isinstance(self.metric_columns, list):
@@ -194,7 +194,7 @@ class ConsoleRenderer:
             + "Legend"
             + self.colors.end
             + " (Metric: "
-            + str(self.primary_metric)
+            + self.primary_metric
             + " Min: {:.2f}".format(self.min_metric)
             + " Max: {:.2f}".format(self.max_metric)
             + ")\n"
@@ -267,10 +267,7 @@ class ConsoleRenderer:
                 else:
                     metric_str += " [{}]".format(annotation_content)
 
-            if isinstance(dataframe.columns, pd.MultiIndex):
-                node_name = dataframe.loc[df_index, (self.name, "")]
-            else:
-                node_name = dataframe.loc[df_index, self.name]
+            node_name = dataframe.loc[df_index, self.name]
             if self.expand is False:
                 if len(node_name) > 39:
                     node_name = (

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -929,6 +929,7 @@ class GraphFrame:
     def tree(
         self,
         metric_column=None,
+        annotation_column=None,
         precision=3,
         name_column="name",
         expand_name=False,
@@ -967,6 +968,7 @@ class GraphFrame:
             self.graph.roots,
             self.dataframe,
             metric_column=metric_column,
+            annotation_column=annotation_column,
             precision=precision,
             name_column=name_column,
             expand_name=expand_name,

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -945,7 +945,7 @@ class GraphFrame:
         min_value=None,
         max_value=None,
     ):
-        """Visualize the Thicket as a tree
+        """Visualize the Hatchet graphframe as a tree
 
         Arguments:
             metric_column (str, list, optional): Columns to use the metrics from. Defaults to None.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -949,7 +949,7 @@ class GraphFrame:
 
         Arguments:
             metric_column (str, list, optional): Columns to use the metrics from. Defaults to None.
-            annotation_column (str, optional): Column to use to adding an annotation. Defaults to None.
+            annotation_column (str, optional): Column to use as an annotation. Defaults to None.
             precision (int, optional): Precision of shown numbers. Defaults to 3.
             name_column (str, optional): Column of the node name. Defaults to "name".
             expand_name (bool, optional): Limits the lenght of the node name. Defaults to False.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -942,6 +942,8 @@ class GraphFrame:
         invert_colormap=False,
         colormap_annotations=None,
         render_header=True,
+        min_value=None,
+        max_value=None,
     ):
         """Format this graphframe as a tree and return the resulting string."""
         color = sys.stdout.isatty()
@@ -982,6 +984,8 @@ class GraphFrame:
             invert_colormap=invert_colormap,
             colormap_annotations=colormap_annotations,
             render_header=render_header,
+            min_value=min_value,
+            max_value=max_value,
         )
 
     def to_dot(self, metric=None, name="name", rank=0, thread=0, threshold=0.0):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -945,7 +945,29 @@ class GraphFrame:
         min_value=None,
         max_value=None,
     ):
-        """Format this graphframe as a tree and return the resulting string."""
+        """Visualize the Thicket as a tree
+
+        Arguments:
+            metric_column (str, list, optional): Columns to use the metrics from. Defaults to None.
+            annotation_column (str, optional): Column to use to adding an annotation. Defaults to None.
+            precision (int, optional): Precision of shown numbers. Defaults to 3.
+            name_column (str, optional): Column of the node name. Defaults to "name".
+            expand_name (bool, optional): Limits the lenght of the node name. Defaults to False.
+            context_column (str, optional): Shows the file this function was called in (Available with HPCToolkit). Defaults to "file".
+            rank (int, optional): Specifies the rank to take the data from. Defaults to 0.
+            thread (int, optional): Specifies the thread to take the data from. Defaults to 0.
+            depth (int, optional): Sets the maximum depth of the tree. Defaults to 10000.
+            highlight_name (bool, optional): Highlights the names of the nodes. Defaults to False.
+            colormap (str, optional): Specifies a colormap to use. Defaults to "RdYlGn".
+            invert_colormap (bool, optional): Reverts the chosen colormap. Defaults to False.
+            colormap_annotations (str, list, dict, optional): Either provide the name of a colormap, a list of colors to use or a dictionary which maps the used annotations to a color. Defaults to None.
+            render_header (bool, optional): Shows the Preamble. Defaults to True.
+            min_value (int, optional): Overwrites the min value for the coloring legend. Defaults to None.
+            max_value (int, optional): Overwrites the max value for the coloring legend. Defaults to None.
+
+        Returns:
+            str: String representation of the tree, ready to print
+        """
         color = sys.stdout.isatty()
         shell = None
         if metric_column is None:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -940,6 +940,7 @@ class GraphFrame:
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        colormap_annotations=None,
         render_header=True,
     ):
         """Format this graphframe as a tree and return the resulting string."""
@@ -979,6 +980,7 @@ class GraphFrame:
             highlight_name=highlight_name,
             colormap=colormap,
             invert_colormap=invert_colormap,
+            colormap_annotations=colormap_annotations,
             render_header=render_header,
         )
 

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -13,7 +13,6 @@ import sys
 from hatchet import GraphFrame
 from hatchet.readers.caliper_reader import CaliperReader
 from hatchet.util.executable import which
-from hatchet.external.console import ConsoleRenderer
 
 caliperreader_avail = True
 try:

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -159,46 +159,18 @@ def test_filter_squash_unify_caliper_data(lulesh_caliper_json):
     squash_gf2.dataframe.set_index(gf2_index_names, inplace=True)
 
 
-def test_tree(lulesh_caliper_json):
+def test_tree(monkeypatch, lulesh_caliper_json):
     """Sanity test a GraphFrame object with known data."""
+    monkeypatch.setattr("sys.stdout.isatty", (lambda: False))
     gf = GraphFrame.from_caliper(str(lulesh_caliper_json))
+    output = gf.tree(metric_column="time")
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
     assert "121489.000 main" in output
     assert "663.000 LagrangeElements" in output
     assert "21493.000 CalcTimeConstraintsForElems" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time (inc)")
+
     assert "662712.000 EvalEOSForElems" in output
     assert "2895319.000 LagrangeNodal" in output
 

--- a/hatchet/tests/cprofile.py
+++ b/hatchet/tests/cprofile.py
@@ -7,7 +7,6 @@ import numpy as np
 import re
 
 from hatchet import GraphFrame
-from hatchet.external.console import ConsoleRenderer
 
 
 def test_graphframe(hatchet_cycle_pstats):

--- a/hatchet/tests/cprofile.py
+++ b/hatchet/tests/cprofile.py
@@ -27,43 +27,16 @@ def test_graphframe(hatchet_cycle_pstats):
             assert gf.dataframe[col].dtype == object
 
 
-def test_tree(hatchet_cycle_pstats):
+def test_tree(monkeypatch, hatchet_cycle_pstats):
+    monkeypatch.setattr("sys.stdout.isatty", (lambda: False))
     gf = GraphFrame.from_cprofile(str(hatchet_cycle_pstats))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time")
+
     assert "g pstats_reader_test.py" in output
     assert "<method 'disable' ...Profiler' objects> ~" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time (inc)")
+
     assert "f pstats_reader_test.py" in output
     assert re.match("(.|\n)*recursive(.|\n)*recursive", output)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -19,7 +19,6 @@ from hatchet.graphframe import InvalidFilter, EmptyFilter
 from hatchet.frame import Frame
 from hatchet.graph import Graph
 from hatchet.node import Node
-from hatchet.external.console import ConsoleRenderer
 from hatchet.version import __version__
 
 

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -9,7 +9,6 @@ import os
 
 from hatchet import GraphFrame
 from hatchet.readers.hpctoolkit_reader import HPCToolkitReader
-from hatchet.external.console import ConsoleRenderer
 
 modules = [
     "cpi",

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -98,47 +98,20 @@ def test_graphframe(data_dir, calc_pi_hpct_db):
         assert v1 == v2
 
 
-def test_tree(calc_pi_hpct_db):
+def test_tree(monkeypatch, calc_pi_hpct_db):
+    monkeypatch.setattr("sys.stdout.isatty", (lambda: False))
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time")
+
     assert "0.000 <program root> <unknown file>" in output
     assert (
         "0.000 198:MPIR_Init_thread /tmp/dpkg-mkdeb.gouoc49UG7/src/mvapich/src/build/../src/mpi/init/initthread.c"
         in output
     )
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time (inc)")
+
     assert "17989.000 interp.c:0 interp.c" in output
     assert (
         "999238.000 230:psm_dofinalize /tmp/dpkg-mkdeb.gouoc49UG7/src/mvapich/src/build/../src/mpid/ch3/channels/psm/src/psm_exit.c"

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -8,7 +8,6 @@ import json
 import numpy as np
 
 from hatchet import GraphFrame
-from hatchet.external.console import ConsoleRenderer
 
 
 def test_graphframe(hatchet_pyinstrument_json):

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -73,45 +73,18 @@ def test_graphframe(hatchet_pyinstrument_json):
             assert gf.dataframe[col].dtype == object
 
 
-def test_tree(hatchet_pyinstrument_json):
+def test_tree(monkeypatch, hatchet_pyinstrument_json):
     """Sanity test a GraphFrame object with known data."""
+    monkeypatch.setattr("sys.stdout.isatty", (lambda: False))
     gf = GraphFrame.from_pyinstrument(str(hatchet_pyinstrument_json))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time")
+
     assert "0.000 <module> examples.py" in output
     assert "0.025 read hatchet/readers/caliper_reader.py" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time (inc)")
+
     assert "0.478 <module> examples.py" in output
     assert "0.063 from_caliper_json hatchet/graphframe.py" in output
 

--- a/hatchet/tests/tau.py
+++ b/hatchet/tests/tau.py
@@ -6,7 +6,6 @@
 import numpy as np
 
 from hatchet import GraphFrame
-from hatchet.external.console import ConsoleRenderer
 
 
 def test_graphframe(tau_profile_dir):

--- a/hatchet/tests/tau.py
+++ b/hatchet/tests/tau.py
@@ -24,48 +24,21 @@ def test_graphframe(tau_profile_dir):
     # TODO: add tests to confirm values in dataframe
 
 
-def test_tree(tau_profile_dir):
+def test_tree(monkeypatch, tau_profile_dir):
     """Sanity test a GraphFrame object with known data."""
+    monkeypatch.setattr("sys.stdout.isatty", (lambda: False))
     gf = GraphFrame.from_tau(str(tau_profile_dir))
 
     # check the tree for rank 0
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time", rank=0)
+
     assert "449.000 .TAU application" in output
     assert "4458.000 MPI_Finalize()" in output
     assert "218.000 MPI_Bcast()" in output
 
     # check the tree for rank 1
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="",
-        rank=1,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
+    output = gf.tree(metric_column="time", rank=1)
+
     assert "419.000 .TAU application" in output
     assert "4894.000 MPI_Finalize()" in output
     assert "333.000 MPI_Bcast()" in output

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -38,48 +38,12 @@ def test_graphframe(timemory_json_data):
 
 
 @pytest.mark.skipif(not timemory_avail, reason="timemory package not available")
-def test_tree(timemory_json_data):
+def test_tree(monkeypatch, timemory_json_data):
     """Sanity test a GraphFrame object with known data."""
+    monkeypatch.setattr("sys.stdout.isatty", (lambda: False))
     gf = GraphFrame.from_timemory(timemory_json_data)
 
-    print(gf.tree("sum.wall_clock"))
-
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="sum.wall_clock",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
-
-    print(output)
-
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="sum.wall_clock",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        colormap="RdYlGn",
-        invert_colormap=False,
-        render_header=True,
-    )
-
+    output = gf.tree(metric_column="sum.wall_clock")
     print(output)
 
 

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -6,7 +6,6 @@
 import numpy as np
 
 from hatchet import GraphFrame
-from hatchet.external.console import ConsoleRenderer
 
 import pytest
 


### PR DESCRIPTION
This PR adds the possibility to plot trees with an additional tree annotation

_New features:_
- It is possible to specify a column that is used to add annotations to the tree. Additionally, it is possible to specify either a colormap, a list of colors to cycle through, or a direct mapping as a dictionary which maps the available annotations to a color.  
- Option to overwrite min and max values, which are extracted from the metric columns by default. This can be helpful if multiple trees should be compared at the same time, so that they share the same coloring schema.