### PR TITLE
sorting tree by hatchet_nid, and tests

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -149,7 +149,7 @@ class ConsoleRenderer:
         else:
             self.lr_arrows = {"◀": u"< ", "▶": u"> "}
 
-        for root in sorted(roots, key=lambda n: n.frame):
+        for root in sorted(roots, key=lambda n: n._hatchet_nid):
             result += self.render_frame(root, dataframe)
 
         if self.color is True:
@@ -312,7 +312,7 @@ class ConsoleRenderer:
             # large complex graphs
             if node not in self.visited:
                 self.visited.append(node)
-                sorted_children = sorted(node.children, key=lambda n: n.frame)
+                sorted_children = sorted(node.children, key=lambda n: n._hatchet_nid)
                 if sorted_children:
                     last_child = sorted_children[-1]
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -581,6 +581,8 @@ class GraphFrame:
         for root in self.graph.roots:
             rewire(root, None, visited)
         graph = Graph(new_roots)
+        if self.graph.node_ordering:
+            graph.node_ordering = True
         graph.enumerate_traverse()
 
         # reindex new dataframe with new nodes

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -434,11 +434,12 @@ class CaliperNativeReader:
         df_metrics.columns = new_cols
 
         # create list of exclusive and inclusive metric columns
+        ignore_columns = ["mpi.rank", "aggregate.slot", "Node order"]
         exc_metrics = []
         inc_metrics = []
         for column in self.metric_cols:
-            # ignore rank as an exc or inc metric
-            if column == "mpi.rank":
+            # ignore certain columns as an exc or inc metric
+            if column in ignore_columns:
                 continue
 
             # add new column names to list of metrics if inc or inclusive in

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -289,6 +289,13 @@ def test_graphframe_native_lulesh_from_file_node_order(caliper_ordered_cali):
         node_data = gf.dataframe.iloc[i]["Total time"]
         assert node_data == expected_data_order[i]
 
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
+
 
 @pytest.mark.skipif(
     not caliperreader_avail, reason="needs caliper-reader package to be loaded"
@@ -356,6 +363,13 @@ def test_graphframe_native_lulesh_from_caliperreader_node_order(caliper_ordered_
         node_data = gf.dataframe.iloc[i]["Total time"]
         assert node_data == expected_data_order[i]
 
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
+
 
 def test_graphframe_lulesh_from_json_node_order(caliper_ordered_json):
     """Check the order of output from the Caliper reader by examining a known json with node order column."""
@@ -420,6 +434,13 @@ def test_graphframe_lulesh_from_json_node_order(caliper_ordered_json):
         node_time = gf.dataframe.iloc[i]["time"]
         assert node_time == expected_data_order[i]
 
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
+
 
 def test_graphframe_native_lulesh_from_duplicate_node_order(caliper_ordered_dup):
     """Check the order of output from the native Caliper reader by examining a known input with node order column."""
@@ -482,6 +503,13 @@ def test_graphframe_native_lulesh_from_duplicate_node_order(caliper_ordered_dup)
         assert node_name == expected_order[i]
         node_data = gf.dataframe.iloc[i]["Total time"]
         assert node_data == expected_data_order[i]
+
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
 
 
 def test_graphframe_lulesh_from_duplicate_json_node_order(caliper_ordered_json_dup):
@@ -546,6 +574,13 @@ def test_graphframe_lulesh_from_duplicate_json_node_order(caliper_ordered_json_d
         assert node_name == expected_order[i]
         node_time = gf.dataframe.iloc[i]["time"]
         assert node_time == expected_data_order[i]
+
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
 
 
 def test_graphframe_native_lulesh_from_file_node_order_mpi(caliper_ordered_cali_mpi):
@@ -623,6 +658,13 @@ def test_graphframe_native_lulesh_from_file_node_order_mpi(caliper_ordered_cali_
         assert node_name == expected_order[i]
         node_data = gf.dataframe.iloc[i]["Total time"]
         assert node_data == expected_data_order[i]
+
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
 
 
 @pytest.mark.skipif(
@@ -707,6 +749,63 @@ def test_graphframe_native_lulesh_from_caliperreader_node_order_mpi(
         assert node_name == expected_order[i]
         node_data = gf.dataframe.iloc[i]["Total time"]
         assert node_data == expected_data_order[i]
+
+    # check the tree ordering is correct as well
+    output = gf.tree(metric_column="nid")
+    for i in range(1, 20):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
+
+
+def test_graphframe_squash_file_node_order(caliper_ordered_cali):
+    """Check the order of output from the native Caliper reader by examining a known input with node order column."""
+
+    gf = GraphFrame.from_caliperreader(str(caliper_ordered_cali))
+
+    assert len(gf.dataframe.groupby("name")) == 19
+    assert "Node order" not in gf.dataframe.columns
+
+    filtered_gf = gf.filter(lambda x: x["nid"] > 10)
+    assert len(filtered_gf.dataframe.groupby("name")) == 9
+
+    expected_order = [
+        "LagrangeElements",
+        "CalcLagrangeElements",
+        "CalcKinematicsForElems",
+        "CalcQForElems",
+        "CalcMonotonicQForElems",
+        "ApplyMaterialPropertiesForElems",
+        "EvalEOSForElems",
+        "CalcEnergyForElems",
+        "CalcTimeConstraintsForElems",
+    ]
+
+    expected_data_order = [
+        0.614079,
+        0.175102,
+        0.168127,
+        0.136318,
+        0.038575,
+        0.299062,
+        0.293046,
+        0.190395,
+        0.010707,
+    ]
+
+    for i in range(0, filtered_gf.dataframe.shape[0]):
+        # check if the rows are in the expected order
+        node_name = filtered_gf.dataframe.iloc[i]["name"]
+        assert node_name == expected_order[i]
+        node_data = filtered_gf.dataframe.iloc[i]["Total time"]
+        assert node_data == expected_data_order[i]
+
+    # check the tree ordering is correct as well
+    output = filtered_gf.tree(metric_column="nid")
+    for i in range(10, 19):
+        location = output.find(str(i))
+        assert location != 0
+        output = output[location:]
 
 
 def test_inclusive_time_calculation(lulesh_caliper_json):


### PR DESCRIPTION
The tree printout was sorting alphabetically so it looked different than the dataframe which sorts by _hatchet_nid. Now the tree sorts roots and children by the _hatchet_nid and matches the dataframe.