### PR TITLE
Added Jupyter Version Check to Roundtrip Import

### DIFF
--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -5,10 +5,11 @@
 
 
 class VersionError(Exception):
-    '''
-        Define a version error class with the same features of the base exception class.
-        Allows us to catch the very specific ipython version error and throw a warning.
-    '''
+    """
+    Define a version error class with the same features of the base exception class.
+    Allows us to catch the very specific ipython version error and throw a warning.
+    """
+
     pass
 
 
@@ -20,11 +21,13 @@ try:
     Roundtrip
 
     # Testing IPython version
-    if (int(IPython.__version__.split('.')[0]) > 7):
+    if int(IPython.__version__.split(".")[0]) > 7:
         raise VersionError()
 
 except ImportError:
     pass
 
 except VersionError:
-    print("Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x.")
+    print(
+        "Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x."
+    )

--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -2,7 +2,7 @@
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
-import traceback
+
 
 class VersionError(Exception):
     '''
@@ -11,6 +11,7 @@ class VersionError(Exception):
     '''
     pass
 
+
 try:
     from .roundtrip.roundtrip.manager import Roundtrip
     import IPython
@@ -18,8 +19,8 @@ try:
     # Refrencing Roundtrip here to resolve scope issues with import
     Roundtrip
 
-    #Testing IPython version
-    if(int(IPython.__version__.split('.')[0]) > 7):
+    # Testing IPython version
+    if (int(IPython.__version__.split('.')[0]) > 7):
         raise VersionError()
 
 except ImportError:

--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -2,9 +2,28 @@
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+import traceback
+
+class VersionError(Exception):
+    '''
+        Define a version error class with the same features of the base exception class.
+        Allows us to catch the very specific ipython version error and throw a warning.
+    '''
+    pass
+
 try:
     from .roundtrip.roundtrip.manager import Roundtrip
+    import IPython
 
+    # Refrencing Roundtrip here to resolve scope issues with import
     Roundtrip
+
+    #Testing IPython version
+    if(int(IPython.__version__.split('.')[0]) > 7):
+        raise VersionError()
+
 except ImportError:
     pass
+
+except VersionError:
+    print("Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x.")


### PR DESCRIPTION
Added a version check to location of Roundtrip import. Will throw warning if Roundtrip fails to load in a newer Jupyter notebook version.