### PR TITLE
Preserve Node Ordering in Graph Copy

### DIFF
--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -187,6 +187,7 @@ class Graph:
                 new.children.append(old_to_new[old_child])
 
         graph = Graph([old_to_new[r] for r in self.roots])
+        graph.node_ordering = self.node_ordering
         graph.enumerate_traverse()
 
         return graph

--- a/hatchet/tests/graph.py
+++ b/hatchet/tests/graph.py
@@ -40,7 +40,10 @@ def test_copy():
     diamond_subdag = Node.from_lists(("a", ("b", d), ("c", d)))
     g = Graph.from_lists(("e", "f", diamond_subdag), ("g", diamond_subdag, "h"))
 
-    assert g.copy() == g
+    gc = g.copy()
+
+    assert gc == g
+    assert gc.node_ordering == g.node_ordering
 
 
 def test_union_dag():


### PR DESCRIPTION
# Summary
`self.node_ordering` is always initialized to false when creating a graph. The `copy` function creates a new graph, so even if the parent graph `self.node_ordering=True`, the copy graph will be `node_ordering=False`, which is undesirable.