### PR TITLE
Change "nid" Casted Value in caliper_native_reader to np.int64

### DIFF
--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -527,7 +527,7 @@ class CaliperNativeReader:
             with self.timer.phase("data frame"):
                 # merge the metrics and node dataframes on the nid column
                 dataframe = pd.merge(df_metrics, self.df_nodes, on="nid")
-                dataframe["nid"] = dataframe["nid"].astype(pd.Int64Dtype())
+                dataframe["nid"] = dataframe["nid"].astype(np.int64)
 
                 # set the index to be a MultiIndex
                 indices = ["node"]

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -527,7 +527,7 @@ class CaliperNativeReader:
             with self.timer.phase("data frame"):
                 # merge the metrics and node dataframes on the nid column
                 dataframe = pd.merge(df_metrics, self.df_nodes, on="nid")
-                dataframe["nid"] = dataframe["nid"].astype(np.int64)
+                dataframe["nid"] = dataframe["nid"].astype(self.__cali_type_dict["int"])
 
                 # set the index to be a MultiIndex
                 indices = ["node"]

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -527,7 +527,7 @@ class CaliperNativeReader:
             with self.timer.phase("data frame"):
                 # merge the metrics and node dataframes on the nid column
                 dataframe = pd.merge(df_metrics, self.df_nodes, on="nid")
-                dataframe["nid"] = dataframe["nid"].astype(self.__cali_type_dict["int"])
+                dataframe["nid"] = dataframe["nid"].astype(self.__cali_type_dict["double"])
 
                 # set the index to be a MultiIndex
                 indices = ["node"]

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -527,7 +527,9 @@ class CaliperNativeReader:
             with self.timer.phase("data frame"):
                 # merge the metrics and node dataframes on the nid column
                 dataframe = pd.merge(df_metrics, self.df_nodes, on="nid")
-                dataframe["nid"] = dataframe["nid"].astype(self.__cali_type_dict["double"])
+                dataframe["nid"] = dataframe["nid"].astype(
+                    self.__cali_type_dict["double"]
+                )
 
                 # set the index to be a MultiIndex
                 indices = ["node"]

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -5,7 +5,6 @@
 
 import subprocess
 import numpy as np
-import pandas as pd
 
 import pytest
 import sys

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -195,7 +195,7 @@ def test_graphframe_native_lulesh_from_file(lulesh_caliper_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == np.int64
+            assert gf.dataframe[col].dtype == np.float64
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 
@@ -221,7 +221,7 @@ def test_graphframe_native_lulesh_from_caliperreader(lulesh_caliper_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == np.int64
+            assert gf.dataframe[col].dtype == np.float64
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 
@@ -881,7 +881,7 @@ def test_graphframe_timeseries_lulesh_from_file(caliper_timeseries_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == np.int64
+            assert gf.dataframe[col].dtype == np.float64
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -196,7 +196,7 @@ def test_graphframe_native_lulesh_from_file(lulesh_caliper_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == pd.Int64Dtype()
+            assert gf.dataframe[col].dtype == np.int64
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 
@@ -222,7 +222,7 @@ def test_graphframe_native_lulesh_from_caliperreader(lulesh_caliper_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == pd.Int64Dtype()
+            assert gf.dataframe[col].dtype == np.int64
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 
@@ -882,7 +882,7 @@ def test_graphframe_timeseries_lulesh_from_file(caliper_timeseries_cali):
         if col in ("time (inc)", "time"):
             assert gf.dataframe[col].dtype == np.float64
         elif col in ("nid", "rank"):
-            assert gf.dataframe[col].dtype == pd.Int64Dtype()
+            assert gf.dataframe[col].dtype == np.int64
         elif col in ("name", "node"):
             assert gf.dataframe[col].dtype == object
 


### PR DESCRIPTION
# Summary
While working with `GraphFrame.to_hdf()` I noticed that the `pytables` backend does not support the current datatype of the `nid` column, causing:
```
TypeError: objects of type ``IntegerArray`` are not supported in this context, sorry; supported objects are: NumPy array, record or scalar; homogeneous list or tuple, integer, float, complex or bytes
```
[Most datatypes in Pandas columns get casted to Numpy datatypes](https://pandas.pydata.org/docs/reference/arrays.html#:~:text=For%20most%20data%20types%2C%20pandas%20uses%20NumPy%20arrays%20as%20the%20concrete%20objects%20contained%20with%20a%20Index%2C%20Series%2C%20or%20DataFrame.) . We needed to use `pd.Int64Dtype()` for time series data since `np.int64` does not support NaN values. By casting the "nid" column to `np.float64` instead of `pd.Int64Dtype()`, the issue is fixed with `pytables` and we can support NaN values for time series.