### PR TITLE
Support Printing Tree for MultiIndex Columns

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -327,7 +327,10 @@ class ConsoleRenderer:
                 else:
                     metric_str += " [{}]".format(annotation_content)
 
-            node_name = dataframe.loc[df_index, self.name]
+            if isinstance(dataframe.columns, pd.MultiIndex):
+                node_name = dataframe.loc[df_index, (self.name, "")]
+            else:
+                node_name = dataframe.loc[df_index, self.name]
             if self.expand is False:
                 if len(node_name) > 39:
                     node_name = (


### PR DESCRIPTION
# Summary
MultiIndex columns **do not** occur natively in Hatchet, however Thicket has some cases where the columns in a `Thicket.statsframe.dataframe` will become MultiIndex. This is relevant since the `Thicket.statsframe` is a `Hatchet.GraphFrame`, so to support printing the `Thicket.statsframe.tree()`, there must be a separate check for MultiIndex columns in Hatchet. This should **not** impact the functionality of Hatchet users using `GraphFrame.tree()`, since the `GraphFrame.dataframe` wont be MultiIndex if only using Hatchet by itself.

# Current Issue
The current code `dataframe.loc[df_index, self.name]` returns a series when the columns are MultiIndex, which looks unsightly in the tree printout. We can avoid this by slightly tweaking the format to index directly to the string value.

![image](https://github.com/LLNL/hatchet/assets/32579379/f700795e-0361-41be-a86a-b6d25c03edc8)

# Why hasn't this been an issue before?
`Thicket.tree()` prints on the `Thicket.statsframe.dataframe` aswell, but it handles this case appropriately by checking for the MultiIndex. So the current `Thicket.tree()` function can be used to avoid this problem. However, once https://github.com/LLNL/thicket/pull/118 is merged, the `Thicket.tree()` will print on the `Thicket.dataframe` instead of the statsframe. Therefore, this functionality is necessary to continue to support both `Thicket.tree()` and `Thicket.statsframe.tree()`.
