### PR TITLE
Expose old_to_new object in squash

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -646,6 +646,7 @@ class GraphFrame:
         )
         if update_inc_cols:
             new_gf.update_inclusive_columns()
+        new_gf.old_to_new = old_to_new
         return new_gf
 
     def _init_sum_columns(self, columns, out_columns):


### PR DESCRIPTION
# Summary
It is necessary to have the mapping to new node objects for Thicket operations that leverage `GraphFrame.squash()`