### PR TITLE
Adds support for multi-indexed column names

### DIFF
--- a/hatchet/query/compat.py
+++ b/hatchet/query/compat.py
@@ -33,7 +33,6 @@ COMPATABILITY_ENGINE = QueryEngine()
 
 
 class AbstractQuery(ABC):
-
     """Base class for all 'old-style' queries."""
 
     @abstractmethod
@@ -87,7 +86,6 @@ class AbstractQuery(ABC):
 
 
 class NaryQuery(AbstractQuery):
-
     """Base class for all compound queries that act on
     and merged N separate subqueries."""
 
@@ -149,7 +147,6 @@ class NaryQuery(AbstractQuery):
 
 
 class AndQuery(NaryQuery):
-
     """Compound query that returns the intersection of the results
     of the subqueries."""
 
@@ -160,8 +157,7 @@ class AndQuery(NaryQuery):
             *args (AbstractQuery, str, or list): the subqueries to be performed
         """
         warnings.warn(
-            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-            future. Please use new-style queries (e.g., hatchet.query.ConjunctionQuery) instead.",
+            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries (e.g., hatchet.query.ConjunctionQuery) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -181,7 +177,6 @@ IntersectionQuery = AndQuery
 
 
 class OrQuery(NaryQuery):
-
     """Compound query that returns the union of the results
     of the subqueries"""
 
@@ -192,8 +187,7 @@ class OrQuery(NaryQuery):
             *args (AbstractQuery, str, or list): the subqueries to be performed
         """
         warnings.warn(
-            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-            future. Please use new-style queries (e.g., hatchet.query.DisjunctionQuery) instead.",
+            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries (e.g., hatchet.query.DisjunctionQuery) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -213,7 +207,6 @@ UnionQuery = OrQuery
 
 
 class XorQuery(NaryQuery):
-
     """Compound query that returns the symmetric difference
     (i.e., set-based XOR) of the results of the subqueries"""
 
@@ -224,8 +217,7 @@ class XorQuery(NaryQuery):
             *args (AbstractQuery, str, or list): the subqueries to be performed
         """
         warnings.warn(
-            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-            future. Please use new-style queries (e.g., hatchet.query.ExclusiveDisjunctionQuery) instead.",
+            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries (e.g., hatchet.query.ExclusiveDisjunctionQuery) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -245,7 +237,6 @@ SymDifferenceQuery = XorQuery
 
 
 class NotQuery(NaryQuery):
-
     """Compound query that returns all nodes in the GraphFrame that
     are not returned from the subquery."""
 
@@ -256,8 +247,7 @@ class NotQuery(NaryQuery):
             *args (AbstractQuery, str, or list): the subquery to be performed
         """
         warnings.warn(
-            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-            future. Please use new-style queries (e.g., hatchet.query.NegationQuery) instead.",
+            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries (e.g., hatchet.query.NegationQuery) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -273,7 +263,6 @@ class NotQuery(NaryQuery):
 
 
 class QueryMatcher(AbstractQuery):
-
     """Processes and applies base syntax queries and Object-based queries to GraphFrames."""
 
     def __init__(self, query=None):
@@ -284,10 +273,7 @@ class QueryMatcher(AbstractQuery):
                                     into its internal representation
         """
         warnings.warn(
-            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-            future. Please use new-style queries instead. For QueryMatcher, the equivalent \
-            new-style queries are hatchet.query.Query for base-syntax queries and \
-            hatchet.query.ObjectQuery for the object-dialect.",
+            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries instead. For QueryMatcher, the equivalent new-style queries are hatchet.query.Query for base-syntax queries and hatchet.query.ObjectQuery for the object-dialect.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -348,7 +334,6 @@ class QueryMatcher(AbstractQuery):
 
 
 class CypherQuery(QueryMatcher):
-
     """Processes and applies Strinb-based queries to GraphFrames."""
 
     def __init__(self, cypher_query):
@@ -358,9 +343,7 @@ class CypherQuery(QueryMatcher):
             cypher_query (str): the String-based query
         """
         warnings.warn(
-            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-            future. Please use new-style queries instead. For CypherQuery, the equivalent \
-            new-style query is hatchet.query.StringQuery.",
+            "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries instead. For CypherQuery, the equivalent new-style query is hatchet.query.StringQuery.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -386,8 +369,7 @@ def parse_cypher_query(cypher_query):
         (CypherQuery): a Hatchet query for this String-based query
     """
     warnings.warn(
-        "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the \
-        future. Please use new-style queries (e.g., hatchet.query.parse_string_dialect) instead.",
+        "Old-style queries are deprecated as of Hatchet 2023.1.0 and will be removed in the future. Please use new-style queries (e.g., hatchet.query.parse_string_dialect) instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/hatchet/query/object_dialect.py
+++ b/hatchet/query/object_dialect.py
@@ -106,6 +106,9 @@ def _process_predicate(attr_filter, multi_index_mode):
 
         matches = True
         for k, v in attr_filter.items():
+            metric_name = k
+            if isinstance(k, (tuple, list)) and len(k) == 1:
+                metric_name = k[0]
             try:
                 _ = iter(v)
                 # Manually raise TypeError if v is a string so that
@@ -114,10 +117,12 @@ def _process_predicate(attr_filter, multi_index_mode):
                     raise TypeError
             # Runs if v is not iterable (e.g., list, tuple, etc.)
             except TypeError:
-                matches = matches and filter_single_series(df_row, k, v)
+                matches = matches and filter_single_series(df_row, metric_name, v)
             else:
                 for single_value in v:
-                    matches = matches and filter_single_series(df_row, k, single_value)
+                    matches = matches and filter_single_series(
+                        df_row, metric_name, single_value
+                    )
         return matches
 
     def filter_dframe(df_row):
@@ -186,16 +191,19 @@ def _process_predicate(attr_filter, multi_index_mode):
         matches = True
         node = df_row.name.to_frame().index[0][0]
         for k, v in attr_filter.items():
+            metric_name = k
+            if isinstance(k, (tuple, list)) and len(k) == 1:
+                metric_name = k[0]
             try:
                 _ = iter(v)
                 if isinstance(v, str):
                     raise TypeError
             except TypeError:
-                matches = matches and filter_single_dframe(node, df_row, k, v)
+                matches = matches and filter_single_dframe(node, df_row, metric_name, v)
             else:
                 for single_value in v:
                     matches = matches and filter_single_dframe(
-                        node, df_row, k, single_value
+                        node, df_row, metric_name, single_value
                     )
         return matches
 
@@ -208,7 +216,6 @@ def _process_predicate(attr_filter, multi_index_mode):
 
 
 class ObjectQuery(Query):
-
     """Class for representing and parsing queries using the Object-based dialect."""
 
     def __init__(self, query, multi_index_mode="off"):

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -701,7 +701,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -724,7 +726,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -771,7 +775,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -794,7 +800,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -839,7 +847,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -862,7 +872,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -902,7 +914,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -925,7 +939,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -970,7 +986,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -993,7 +1011,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1033,7 +1053,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1056,7 +1078,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1101,7 +1125,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1124,7 +1150,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1164,7 +1192,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1187,7 +1217,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1232,7 +1264,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1255,7 +1289,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1295,7 +1331,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1318,7 +1356,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -52,7 +52,8 @@ NumNan: name=ID '.' prop=MetricId 'IS NAN';
 NumNotNan: name=ID '.' prop=MetricId 'IS NOT NAN';
 NumInf: name=ID '.' prop=MetricId 'IS INF';
 NumNotInf: name=ID '.' prop=MetricId 'IS NOT INF';
-MetricId: '(' ids+=STRING[','] ')' | ids=STRING;
+MetricId: '(' ids+=SingleMetricId[','] ')' | ids=SingleMetricId;
+SingleMetricId: INT | STRING;
 """
 
 # TextX metamodel for the String-based dialect

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -8,7 +8,6 @@ import pytest
 import re
 
 import numpy as np
-import pandas as pd
 
 from hatchet import GraphFrame
 from hatchet.node import traversal_order

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -401,9 +401,9 @@ def test_apply(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
-        "list"
-    ] = DummyType()
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
+        DummyType()
+    )
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     query = ObjectQuery(path)
@@ -852,10 +852,14 @@ def test_construct_string_dialect():
     path4 = """MATCH (p)->(3, a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND q."name" STARTS WITH "ibv"
     """
+    path5 = """MATCH (p)->("*")->(q)
+    WHERE p.("name") STARTS WITH "MPI_" AND q.("name") STARTS WITH "ibv"
+    """
     query1 = StringQuery(path1)
     query2 = StringQuery(path2)
     query3 = StringQuery(path3)
     query4 = StringQuery(path4)
+    query5 = StringQuery(path5)
 
     assert query1.query_pattern[0][0] == "."
     assert query1.query_pattern[0][1](mock_node_mpi)
@@ -911,6 +915,17 @@ def test_construct_string_dialect():
     assert query4.query_pattern[3][1](mock_node_time_true)
     assert not query4.query_pattern[3][1](mock_node_time_false)
     assert query4.query_pattern[4][0] == "."
+
+    assert query5.query_pattern[0][0] == "."
+    assert query5.query_pattern[0][1](mock_node_mpi)
+    assert not query5.query_pattern[0][1](mock_node_ibv)
+    assert not query5.query_pattern[0][1](mock_node_time_true)
+    assert query5.query_pattern[1][0] == "*"
+    assert query5.query_pattern[1][1](mock_node_mpi)
+    assert query5.query_pattern[1][1](mock_node_ibv)
+    assert query5.query_pattern[1][1](mock_node_time_true)
+    assert query5.query_pattern[1][1](mock_node_time_false)
+    assert query5.query_pattern[2][0] == "."
 
     invalid_path = """MATCH (p)->({"bad": "wildcard"}, a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND
@@ -1013,9 +1028,9 @@ def test_apply_string_dialect(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
-        "list"
-    ] = DummyType()
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
+        DummyType()
+    )
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -382,9 +382,9 @@ def test_apply(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
-        "list"
-    ] = DummyType()
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
+        DummyType()
+    )
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     query = ObjectQuery(path)
@@ -821,16 +821,16 @@ def test_construct_string_dialect():
     mock_node_ibv = {"name": "ibv_reg_mr"}
     mock_node_time_true = {"time (inc)": 0.1}
     mock_node_time_false = {"time (inc)": 0.001}
-    path1 = u"""MATCH (p)->("*")->(q)
+    path1 = """MATCH (p)->("*")->(q)
     WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
     """
-    path2 = u"""MATCH (p)->(2)->(q)
+    path2 = """MATCH (p)->(2)->(q)
     WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
     """
-    path3 = u"""MATCH (p)->("+", a)->(q)
+    path3 = """MATCH (p)->("+", a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" >= 0.1 AND q."name" STARTS WITH "ibv"
     """
-    path4 = u"""MATCH (p)->(3, a)->(q)
+    path4 = """MATCH (p)->(3, a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND q."name" STARTS WITH "ibv"
     """
     query1 = StringQuery(path1)
@@ -893,7 +893,7 @@ def test_construct_string_dialect():
     assert not query4.query_pattern[3][1](mock_node_time_false)
     assert query4.query_pattern[4][0] == "."
 
-    invalid_path = u"""MATCH (p)->({"bad": "wildcard"}, a)->(q)
+    invalid_path = """MATCH (p)->({"bad": "wildcard"}, a)->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND
     q."name" STARTS WITH "ibv"
     """
@@ -903,7 +903,7 @@ def test_construct_string_dialect():
 
 def test_apply_string_dialect(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
-    path = u"""MATCH (p)->(2, q)->("*", r)->(s)
+    path = """MATCH (p)->(2, q)->("*", r)->(s)
     WHERE p."time (inc)" >= 30.0 AND NOT q."name" STARTS WITH "b"
     AND r."name" =~ "[^b][a-z]+" AND s."name" STARTS WITH "gr"
     """
@@ -920,7 +920,7 @@ def test_apply_string_dialect(mock_graph_literal):
 
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
 
-    path = u"""MATCH (p)->(".")->(q)->("*")
+    path = """MATCH (p)->(".")->(q)->("*")
     WHERE p."time (inc)" >= 30.0 AND q."name" = "bar"
     """
     match = [
@@ -933,14 +933,14 @@ def test_apply_string_dialect(mock_graph_literal):
     query = StringQuery(path)
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
 
-    path = u"""MATCH (p)->(q)->(r)
+    path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND r."time" = 5.0
     """
     match = [root, root.children[0], root.children[0].children[0]]
     query = StringQuery(path)
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
 
-    path = u"""MATCH (p)->(q)->("+", r)
+    path = """MATCH (p)->(q)->("+", r)
     WHERE p."name" = "foo" AND q."name" = "qux" AND r."time (inc)" > 15.0
     """
     match = [
@@ -953,7 +953,7 @@ def test_apply_string_dialect(mock_graph_literal):
     query = StringQuery(path)
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
 
-    path = u"""MATCH (p)->(q)
+    path = """MATCH (p)->(q)
     WHERE p."time (inc)" > 100 OR p."time (inc)" <= 30 AND q."time (inc)" = 20
     """
     roots = gf.graph.roots
@@ -966,21 +966,21 @@ def test_apply_string_dialect(mock_graph_literal):
     query = StringQuery(path)
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
 
-    path = u"""MATCH (p)->("*", q)->(r)
+    path = """MATCH (p)->("*", q)->(r)
     WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"
     """
 
     query = StringQuery(path)
     assert engine.apply(query, gf.graph, gf.dataframe) == []
 
-    path = u"""MATCH (p)->("*")->(q)
+    path = """MATCH (p)->("*")->(q)
     WHERE p."name" = 5 AND q."name" = "whatever"
     """
     with pytest.raises(InvalidQueryFilter):
         query = StringQuery(path)
         engine.apply(query, gf.graph, gf.dataframe)
 
-    path = u"""MATCH (p)->("*")->(q)
+    path = """MATCH (p)->("*")->(q)
     WHERE p."time" = "badstring" AND q."name" = "whatever"
     """
     query = StringQuery(path)
@@ -994,18 +994,18 @@ def test_apply_string_dialect(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
-        "list"
-    ] = DummyType()
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
+        DummyType()
+    )
     gf = GraphFrame.from_literal(bad_field_test_dict)
-    path = u"""MATCH (p)->(q)->(r)
+    path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()
     """
     with pytest.raises(InvalidQueryPath):
         query = StringQuery(path)
         engine.apply(query, gf.graph, gf.dataframe)
 
-    path = u"""MATCH ("*")->(p)->(q)->("*")
+    path = """MATCH ("*")->(p)->(q)->("*")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     match = [
@@ -1052,7 +1052,7 @@ def test_apply_string_dialect(mock_graph_literal):
     query = StringQuery(path)
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
 
-    path = u"""MATCH ("*")->(p)->(q)->("+")
+    path = """MATCH ("*")->(p)->(q)->("+")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     query = StringQuery(path)
@@ -1060,7 +1060,7 @@ def test_apply_string_dialect(mock_graph_literal):
 
     gf.dataframe["time"] = np.NaN
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS NOT NAN"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
@@ -1068,7 +1068,7 @@ def test_apply_string_dialect(mock_graph_literal):
 
     gf.dataframe["time"] = 5.0
     gf.dataframe.at[gf.graph.roots[0], "time"] = np.NaN
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS NAN"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
@@ -1076,7 +1076,7 @@ def test_apply_string_dialect(mock_graph_literal):
 
     gf.dataframe["time"] = np.Inf
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS NOT INF"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
@@ -1084,7 +1084,7 @@ def test_apply_string_dialect(mock_graph_literal):
 
     gf.dataframe["time"] = 5.0
     gf.dataframe.at[gf.graph.roots[0], "time"] = np.Inf
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS INF"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
@@ -1093,7 +1093,7 @@ def test_apply_string_dialect(mock_graph_literal):
     names = gf.dataframe["name"].copy()
     gf.dataframe["name"] = None
     gf.dataframe.at[gf.graph.roots[0], "name"] = names.iloc[0]
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."name" IS NOT NONE"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
@@ -1101,7 +1101,7 @@ def test_apply_string_dialect(mock_graph_literal):
 
     gf.dataframe["name"] = names
     gf.dataframe.at[gf.graph.roots[0], "name"] = None
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."name" IS NONE"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
@@ -1111,13 +1111,13 @@ def test_apply_string_dialect(mock_graph_literal):
 def test_string_conj_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_string_dialect(
-        u"""
+        """
         {MATCH ("*", p) WHERE p."time (inc)" >= 20 AND p."time (inc)" <= 60}
         AND {MATCH ("*", p) WHERE p."time (inc)" >= 60}
         """
     )
     compound_query2 = parse_string_dialect(
-        u"""
+        """
         MATCH ("*", p)
         WHERE {p."time (inc)" >= 20 AND p."time (inc)" <= 60} AND {p."time (inc)" >= 60}
         """
@@ -1139,13 +1139,13 @@ def test_string_conj_compound_query(mock_graph_literal):
 def test_string_disj_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_string_dialect(
-        u"""
+        """
         {MATCH ("*", p) WHERE p."time (inc)" = 5.0}
         OR {MATCH ("*", p) WHERE p."time (inc)" = 10.0}
         """
     )
     compound_query2 = parse_string_dialect(
-        u"""
+        """
         MATCH ("*", p)
         WHERE {p."time (inc)" = 5.0} OR {p."time (inc)" = 10.0}
         """
@@ -1174,13 +1174,13 @@ def test_string_disj_compound_query(mock_graph_literal):
 def test_cypher_exc_disj_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_string_dialect(
-        u"""
+        """
         {MATCH ("*", p) WHERE p."time (inc)" >= 5.0 AND p."time (inc)" <= 10.0}
         XOR {MATCH ("*", p) WHERE p."time (inc)" = 10.0}
         """
     )
     compound_query2 = parse_string_dialect(
-        u"""
+        """
         MATCH ("*", p)
         WHERE {p."time (inc)" >= 5.0 AND p."time (inc)" <= 10.0} XOR {p."time (inc)" = 10.0}
         """
@@ -1215,19 +1215,19 @@ def test_leaf_query(small_mock2):
     nonleaves = list(nodes - set(matches))
     obj_query = ObjectQuery([{"depth": -1}])
     str_query_numeric = parse_string_dialect(
-        u"""
+        """
         MATCH (p)
         WHERE p."depth" = -1
         """
     )
     str_query_is_leaf = parse_string_dialect(
-        u"""
+        """
         MATCH (p)
         WHERE p IS LEAF
         """
     )
     str_query_is_not_leaf = parse_string_dialect(
-        u"""
+        """
         MATCH (p)
         WHERE p IS NOT LEAF
         """
@@ -1265,7 +1265,7 @@ def test_string_dialect_all_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
     query = StringQuery(
-        u"""MATCH (".")->("+", p)
+        """MATCH (".")->("+", p)
         WHERE p."time (inc)" >= 17983.0
         """,
         multi_index_mode="all",
@@ -1296,7 +1296,7 @@ def test_string_dialect_any_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
     query = StringQuery(
-        u"""MATCH (".", p)
+        """MATCH (".", p)
         WHERE p."time" < 24.0
         """,
         multi_index_mode="any",
@@ -1314,7 +1314,7 @@ def test_multi_index_mode_assertion_error(tau_profile_dir):
         _ = ObjectQuery([".", ("*", {"name": "test"})], multi_index_mode="foo")
     with pytest.raises(AssertionError):
         _ = StringQuery(
-            u""" MATCH (".")->("*", p)
+            """ MATCH (".")->("*", p)
             WHERE p."name" = "test"
             """,
             multi_index_mode="foo",

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -401,9 +401,9 @@ def test_apply(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
-        DummyType()
-    )
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
+        "list"
+    ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     query = ObjectQuery(path)
@@ -1028,9 +1028,9 @@ def test_apply_string_dialect(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
-        DummyType()
-    )
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
+        "list"
+    ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [build-system]
-requires = [
-    "setuptools",
-    "wheel",
-    "Cython",
-]
+requires = ["setuptools", "wheel", "Cython"]
 build-backend = "setuptools.build_meta"
 
 [tool.poetry]
@@ -16,6 +12,23 @@ authors = [
     "Todd Gamblin <tgamblin@llnl.gov>",
 ]
 license = "MIT"
+
+[tool.ruff]
+line-length = 88
+target-version = 'py37'
+include = ['\.pyi?$']
+exclude = [
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
This feature adds support for metrics (i.e., DataFrame columns) using pandas `MultiIndex` to the query language.

All changes in this PR are related to the string dialect. This is because the base syntax and object dialect should be able to support this out-of-the-box because they are based in Python.

This PR is linked to LLNL/thicket#154.

This PR should not be merged until both it and LLNL/thicket#154 are ready to merge because the Thicket PR will be used to ensure this feature is actually working.