### PR TITLE
Fix Bug When Importing Roundtrip

### DIFF
--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -15,11 +15,13 @@ class VersionError(Exception):
 
 try:
     import IPython
+
     # Testing IPython version
     if int(IPython.__version__.split(".")[0]) > 7:
         raise VersionError()
 
-    from .roundtrip.roundtrip.manager import Roundtrip    
+    from .roundtrip.roundtrip.manager import Roundtrip
+
     # Refrencing Roundtrip here to resolve scope issues with import
     Roundtrip
 

--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -14,15 +14,14 @@ class VersionError(Exception):
 
 
 try:
-    from .roundtrip.roundtrip.manager import Roundtrip
     import IPython
-
-    # Refrencing Roundtrip here to resolve scope issues with import
-    Roundtrip
-
     # Testing IPython version
     if int(IPython.__version__.split(".")[0]) > 7:
         raise VersionError()
+
+    from .roundtrip.roundtrip.manager import Roundtrip    
+    # Refrencing Roundtrip here to resolve scope issues with import
+    Roundtrip
 
 except ImportError:
     pass

--- a/hatchet/external/roundtrip/roundtrip/manager.py
+++ b/hatchet/external/roundtrip/roundtrip/manager.py
@@ -312,7 +312,7 @@ class RoundTrip:
             js_to_py_converter=from_js_converter,
         )
 
-    def manage_jupter_change(self, event=None):
+    def manage_jupter_change(self, *args, **kwargs):
         """
         Callback function which runs after a cell is executed.
 

--- a/hatchet/external/roundtrip/roundtrip/manager.py
+++ b/hatchet/external/roundtrip/roundtrip/manager.py
@@ -312,7 +312,7 @@ class RoundTrip:
             js_to_py_converter=from_js_converter,
         )
 
-    def manage_jupter_change(self):
+    def manage_jupter_change(self, event=None):
         """
         Callback function which runs after a cell is executed.
 


### PR DESCRIPTION
Currently, Hatchet prints a `TypeError` **in each** Jupyter cell due to a missing positional argument in `manage_jupter_change()` in `hatchet/external/roundtrip/roundtrip/manager.py`. By adding and optional positional argument to the function, we avoid the error when [this line is ran](https://github.com/LLNL/hatchet/blob/6a6d7027056df96bd1c919ab34a9acce81f3b9a1/hatchet/external/roundtrip/roundtrip/manager.py#L547).

Additionally, the import statements are re-arranged to avoid importing the roundtrip module unintentionally, which is happening in the below image.

![image](https://github.com/LLNL/hatchet/assets/32579379/d5a4e8e4-5c38-4dcb-bdf9-186d7d5acd4a)
