### PR TITLE
Fixes common formatting issues messing with CI

### DIFF
--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -765,8 +765,8 @@ def test_sub_decorator(monkeypatch, small_mock1, small_mock2, small_mock3):
     output = gf4.tree(metric_column="time")
 
     assert "0.000 C" in output
-    assert u"nan D ▶" in output
-    assert u"10.000 H ◀" in output
+    assert "nan D ▶" in output
+    assert "10.000 H ◀" in output
 
     gf5 = gf1 - gf3
 
@@ -781,8 +781,8 @@ def test_sub_decorator(monkeypatch, small_mock1, small_mock2, small_mock3):
     output = gf5.tree(metric_column="time (inc)")
 
     assert "15.000 A" in output
-    assert u"5.000 C ◀" in output
-    assert u"10.000 H ◀" in output
+    assert "5.000 C ◀" in output
+    assert "10.000 H ◀" in output
 
 
 def test_div_decorator(monkeypatch, small_mock1, small_mock2):
@@ -804,8 +804,8 @@ def test_div_decorator(monkeypatch, small_mock1, small_mock2):
 
     assert "1.000 C" in output
     assert "inf B" in output
-    assert u"nan D ▶" in output
-    assert u"10.000 H ◀" in output
+    assert "nan D ▶" in output
+    assert "10.000 H ◀" in output
 
 
 def test_groupby_aggregate_simple(mock_dag_literal_module):

--- a/hatchet/tests/query_compat.py
+++ b/hatchet/tests/query_compat.py
@@ -346,7 +346,7 @@ def test_sym_diff_query(mock_graph_literal):
 
 def test_apply_cypher(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
-    path = u"""MATCH (p)->(2, q)->("*", r)->(s)
+    path = """MATCH (p)->(2, q)->("*", r)->(s)
     WHERE p."time (inc)" >= 30.0 AND NOT q."name" STARTS WITH "b"
     AND r."name" =~ "[^b][a-z]+" AND s."name" STARTS WITH "gr"
     """
@@ -362,7 +362,7 @@ def test_apply_cypher(mock_graph_literal):
 
     assert sorted(query.apply(gf)) == sorted(match)
 
-    path = u"""MATCH (p)->(".")->(q)->("*")
+    path = """MATCH (p)->(".")->(q)->("*")
     WHERE p."time (inc)" >= 30.0 AND q."name" = "bar"
     """
     match = [
@@ -375,14 +375,14 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    path = u"""MATCH (p)->(q)->(r)
+    path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND r."time" = 5.0
     """
     match = [root, root.children[0], root.children[0].children[0]]
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    path = u"""MATCH (p)->(q)->("+", r)
+    path = """MATCH (p)->(q)->("+", r)
     WHERE p."name" = "foo" AND q."name" = "qux" AND r."time (inc)" > 15.0
     """
     match = [
@@ -395,7 +395,7 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    path = u"""MATCH (p)->(q)
+    path = """MATCH (p)->(q)
     WHERE p."time (inc)" > 100 OR p."time (inc)" <= 30 AND q."time (inc)" = 20
     """
     roots = gf.graph.roots
@@ -408,21 +408,21 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    path = u"""MATCH (p)->("*", q)->(r)
+    path = """MATCH (p)->("*", q)->(r)
     WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"
     """
 
     query = CypherQuery(path)
     assert query.apply(gf) == []
 
-    path = u"""MATCH (p)->("*")->(q)
+    path = """MATCH (p)->("*")->(q)
     WHERE p."name" = 5 AND q."name" = "whatever"
     """
     with pytest.raises(InvalidQueryFilter):
         query = CypherQuery(path)
         query.apply(gf)
 
-    path = u"""MATCH (p)->("*")->(q)
+    path = """MATCH (p)->("*")->(q)
     WHERE p."time" = "badstring" AND q."name" = "whatever"
     """
     query = CypherQuery(path)
@@ -440,14 +440,14 @@ def test_apply_cypher(mock_graph_literal):
         "list"
     ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
-    path = u"""MATCH (p)->(q)->(r)
+    path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()
     """
     with pytest.raises(InvalidQueryPath):
         query = CypherQuery(path)
         query.apply(gf)
 
-    path = u"""MATCH ("*")->(p)->(q)->("*")
+    path = """MATCH ("*")->(p)->(q)->("*")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     match = [
@@ -494,7 +494,7 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
-    path = u"""MATCH ("*")->(p)->(q)->("+")
+    path = """MATCH ("*")->(p)->(q)->("+")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     query = CypherQuery(path)
@@ -502,7 +502,7 @@ def test_apply_cypher(mock_graph_literal):
 
     gf.dataframe["time"] = np.NaN
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS NOT NAN"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
@@ -510,7 +510,7 @@ def test_apply_cypher(mock_graph_literal):
 
     gf.dataframe["time"] = 5.0
     gf.dataframe.at[gf.graph.roots[0], "time"] = np.NaN
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS NAN"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
@@ -518,7 +518,7 @@ def test_apply_cypher(mock_graph_literal):
 
     gf.dataframe["time"] = np.Inf
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS NOT INF"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
@@ -526,7 +526,7 @@ def test_apply_cypher(mock_graph_literal):
 
     gf.dataframe["time"] = 5.0
     gf.dataframe.at[gf.graph.roots[0], "time"] = np.Inf
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."time" IS INF"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
@@ -535,7 +535,7 @@ def test_apply_cypher(mock_graph_literal):
     names = gf.dataframe["name"].copy()
     gf.dataframe["name"] = None
     gf.dataframe.at[gf.graph.roots[0], "name"] = names.iloc[0]
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."name" IS NOT NONE"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
@@ -543,7 +543,7 @@ def test_apply_cypher(mock_graph_literal):
 
     gf.dataframe["name"] = names
     gf.dataframe.at[gf.graph.roots[0], "name"] = None
-    path = u"""MATCH ("*", p)
+    path = """MATCH ("*", p)
     WHERE p."name" IS NONE"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
@@ -553,13 +553,13 @@ def test_apply_cypher(mock_graph_literal):
 def test_cypher_and_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_cypher_query(
-        u"""
+        """
         {MATCH ("*", p) WHERE p."time (inc)" >= 20 AND p."time (inc)" <= 60}
         AND {MATCH ("*", p) WHERE p."time (inc)" >= 60}
         """
     )
     compound_query2 = parse_cypher_query(
-        u"""
+        """
         MATCH ("*", p)
         WHERE {p."time (inc)" >= 20 AND p."time (inc)" <= 60} AND {p."time (inc)" >= 60}
         """
@@ -576,13 +576,13 @@ def test_cypher_and_compound_query(mock_graph_literal):
 def test_cypher_or_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_cypher_query(
-        u"""
+        """
         {MATCH ("*", p) WHERE p."time (inc)" = 5.0}
         OR {MATCH ("*", p) WHERE p."time (inc)" = 10.0}
         """
     )
     compound_query2 = parse_cypher_query(
-        u"""
+        """
         MATCH ("*", p)
         WHERE {p."time (inc)" = 5.0} OR {p."time (inc)" = 10.0}
         """
@@ -606,13 +606,13 @@ def test_cypher_or_compound_query(mock_graph_literal):
 def test_cypher_xor_compound_query(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     compound_query1 = parse_cypher_query(
-        u"""
+        """
         {MATCH ("*", p) WHERE p."time (inc)" >= 5.0 AND p."time (inc)" <= 10.0}
         XOR {MATCH ("*", p) WHERE p."time (inc)" = 10.0}
         """
     )
     compound_query2 = parse_cypher_query(
-        u"""
+        """
         MATCH ("*", p)
         WHERE {p."time (inc)" >= 5.0 AND p."time (inc)" <= 10.0} XOR {p."time (inc)" = 10.0}
         """
@@ -642,19 +642,19 @@ def test_leaf_query(small_mock2):
     nonleaves = list(nodes - set(matches))
     obj_query = QueryMatcher([{"depth": -1}])
     str_query_numeric = parse_cypher_query(
-        u"""
+        """
         MATCH (p)
         WHERE p."depth" = -1
         """
     )
     str_query_is_leaf = parse_cypher_query(
-        u"""
+        """
         MATCH (p)
         WHERE p IS LEAF
         """
     )
     str_query_is_not_leaf = parse_cypher_query(
-        u"""
+        """
         MATCH (p)
         WHERE p IS NOT LEAF
         """


### PR DESCRIPTION
Now that our minimum supported version of Python is not 2.7 and now that we are using Python 3.9 for `black` and `flake8` in CI, there are a couple of common things that are causing the `black` and `flake8` checks to fail. This PR fixes them