### PR TITLE
Upgrades the version of black used in CI

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -43,7 +43,7 @@ jobs:
         pip install flake8-pytest-importorskip
         pip install --upgrade click==8.0.4
         pip install black==24.4.2
-        pip install flake8==5.0.4
+        pip install flake8==4.0.1
 
     - name: Lint and Format Check with Flake8 and Black
       if: ${{ matrix.python-version == 3.9 }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -42,8 +42,8 @@ jobs:
       run: |
         pip install flake8-pytest-importorskip
         pip install --upgrade click==8.0.4
-        pip install black==21.12b0
-        pip install flake8==4.0.1
+        pip install black==24.4.2
+        pip install flake8==7.0.0
 
     - name: Lint and Format Check with Flake8 and Black
       if: ${{ matrix.python-version == 3.9 }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -43,7 +43,7 @@ jobs:
         pip install flake8-pytest-importorskip
         pip install --upgrade click==8.0.4
         pip install black==24.4.2
-        pip install flake8==6.1.0
+        pip install flake8==5.0.4
 
     - name: Lint and Format Check with Flake8 and Black
       if: ${{ matrix.python-version == 3.9 }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -43,7 +43,7 @@ jobs:
         pip install flake8-pytest-importorskip
         pip install --upgrade click==8.0.4
         pip install black==24.4.2
-        pip install flake8==7.0.0
+        pip install flake8==6.1.0
 
     - name: Lint and Format Check with Flake8 and Black
       if: ${{ matrix.python-version == 3.9 }}

--- a/hatchet/query/compound.py
+++ b/hatchet/query/compound.py
@@ -14,7 +14,6 @@ from .errors import BadNumberNaryQueryArgs
 
 
 class CompoundQuery(object):
-
     """Base class for all types of compound queries."""
 
     def __init__(self, *queries):
@@ -48,7 +47,6 @@ class CompoundQuery(object):
 
 
 class ConjunctionQuery(CompoundQuery):
-
     """A compound query that combines the results of its subqueries
     using set conjunction.
     """
@@ -83,7 +81,6 @@ class ConjunctionQuery(CompoundQuery):
 
 
 class DisjunctionQuery(CompoundQuery):
-
     """A compound query that combines the results of its subqueries
     using set disjunction.
     """
@@ -118,7 +115,6 @@ class DisjunctionQuery(CompoundQuery):
 
 
 class ExclusiveDisjunctionQuery(CompoundQuery):
-
     """A compound query that combines the results of its subqueries
     using exclusive set disjunction.
     """
@@ -153,7 +149,6 @@ class ExclusiveDisjunctionQuery(CompoundQuery):
 
 
 class NegationQuery(CompoundQuery):
-
     """A compound query that inverts/negates the result of
     its single subquery.
     """

--- a/hatchet/query/engine.py
+++ b/hatchet/query/engine.py
@@ -15,7 +15,6 @@ from .string_dialect import parse_string_dialect
 
 
 class QueryEngine:
-
     """Class for applying queries to GraphFrames."""
 
     def __init__(self):

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -482,9 +482,11 @@ class StringQuery(Query):
             None,
             obj.name,
             'df_row[{}] == "{}"'.format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], str)".format(
@@ -500,9 +502,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 'df_row[{}].apply(lambda elem: elem == "{}")'.format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -519,9 +523,11 @@ class StringQuery(Query):
             None,
             obj.name,
             'df_row[{}].startswith("{}")'.format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], str)".format(
@@ -537,9 +543,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 'df_row[{}].apply(lambda elem: elem.startswith("{}"))'.format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -556,9 +564,11 @@ class StringQuery(Query):
             None,
             obj.name,
             'df_row[{}].endswith("{}")'.format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], str)".format(
@@ -574,9 +584,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 'df_row[{}].apply(lambda elem: elem.endswith("{}"))'.format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -594,9 +606,11 @@ class StringQuery(Query):
             obj.name,
             '"{}" in df_row[{}]'.format(
                 obj.val,
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
             ),
             "isinstance(df_row[{}], str)".format(
                 str(tuple(obj.prop.ids))
@@ -611,9 +625,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 'df_row[{}].apply(lambda elem: "{}" in elem)'.format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -631,9 +647,11 @@ class StringQuery(Query):
             obj.name,
             're.match("{}", df_row[{}]) is not None'.format(
                 obj.val,
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
             ),
             "isinstance(df_row[{}], str)".format(
                 str(tuple(obj.prop.ids))
@@ -648,9 +666,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 'df_row[{}].apply(lambda elem: re.match("{}", elem) is not None)'.format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -748,9 +768,11 @@ class StringQuery(Query):
             None,
             obj.name,
             "df_row[{}] == {}".format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], Real)".format(
@@ -825,9 +847,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 "df_row[{}].apply(lambda elem: elem == {})".format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -894,9 +918,11 @@ class StringQuery(Query):
             None,
             obj.name,
             "df_row[{}] < {}".format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], Real)".format(
@@ -964,9 +990,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 "df_row[{}].apply(lambda elem: elem < {})".format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -1033,9 +1061,11 @@ class StringQuery(Query):
             None,
             obj.name,
             "df_row[{}] > {}".format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], Real)".format(
@@ -1103,9 +1133,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 "df_row[{}].apply(lambda elem: elem > {})".format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -1172,9 +1204,11 @@ class StringQuery(Query):
             None,
             obj.name,
             "df_row[{}] <= {}".format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], Real)".format(
@@ -1242,9 +1276,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 "df_row[{}].apply(lambda elem: elem <= {})".format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),
@@ -1311,9 +1347,11 @@ class StringQuery(Query):
             None,
             obj.name,
             "df_row[{}] >= {}".format(
-                str(tuple(obj.prop.ids))
-                if len(obj.prop.ids) > 1
-                else "'{}'".format(obj.prop.ids[0]),
+                (
+                    str(tuple(obj.prop.ids))
+                    if len(obj.prop.ids) > 1
+                    else "'{}'".format(obj.prop.ids[0])
+                ),
                 obj.val,
             ),
             "isinstance(df_row[{}], Real)".format(
@@ -1381,9 +1419,11 @@ class StringQuery(Query):
             obj.name,
             self._add_aggregation_call_to_multi_idx_predicate(
                 "df_row[{}].apply(lambda elem: elem >= {})".format(
-                    str(tuple(obj.prop.ids))
-                    if len(obj.prop.ids) > 1
-                    else "'{}'".format(obj.prop.ids[0]),
+                    (
+                        str(tuple(obj.prop.ids))
+                        if len(obj.prop.ids) > 1
+                        else "'{}'".format(obj.prop.ids[0])
+                    ),
                     obj.val,
                 )
             ),

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -92,7 +92,8 @@ class CaliperNativeReader:
 
     def _reset_metrics(self, metrics):
         """Since the initial functions (i.e. main) are only called once, this keeps a small subset
-        of the timeseries data and resets the rest so future iterations will be filled with nans"""
+        of the timeseries data and resets the rest so future iterations will be filled with nans
+        """
         new_mets = []
         cols_to_keep = [
             "nid",
@@ -106,7 +107,6 @@ class CaliperNativeReader:
         return new_mets
 
     def read_metrics(self, ctx="path"):
-
         """append each metrics table to a list and return the list, split on timeseries_level if exists"""
         metric_dfs = []
         all_metrics = []

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -247,9 +247,11 @@ class CaliperReader:
                     # we will only reach here if path is the "secondary"
                     # hierarchy in the data
                     self.df_json_data["path"] = self.df_json_data["path"].apply(
-                        lambda x: None
-                        if (math.isnan(x))
-                        else self.json_nodes[int(x)]["label"]
+                        lambda x: (
+                            None
+                            if (math.isnan(x))
+                            else self.json_nodes[int(x)]["label"]
+                        )
                     )
                 else:
                     self.df_json_data[self.json_cols[idx]] = self.df_json_data[

--- a/hatchet/readers/gprof_dot_reader.py
+++ b/hatchet/readers/gprof_dot_reader.py
@@ -91,7 +91,7 @@ class GprofDotReader:
 
         # add all nodes with no parents to the list of roots
         list_roots = []
-        for (key, val) in self.name_to_hnode.items():
+        for key, val in self.name_to_hnode.items():
             if not val.parents:
                 list_roots.append(val)
 

--- a/hatchet/readers/timemory_reader.py
+++ b/hatchet/readers/timemory_reader.py
@@ -206,9 +206,9 @@ class TimemoryReader:
                 # match with metric labels if _metric_stat item is a list.
                 elif isinstance(_item, list):
                     for i in range(len(_item)):
-                        _ret[
-                            "{}.{}{}".format(_key, _metric_label[i], _metric_type)
-                        ] = _item[i]
+                        _ret["{}.{}{}".format(_key, _metric_label[i], _metric_type)] = (
+                            _item[i]
+                        )
                 # check if _metric_stat item is not a dict or list
                 else:
                     _ret["{}.{}{}".format(_key, _metric_label, _metric_type)] = _item

--- a/hatchet/vis/static_fixer.py
+++ b/hatchet/vis/static_fixer.py
@@ -8,7 +8,7 @@ from os import walk, path
 
 static_filepath = path.abspath("static/")
 
-for (pt, dirs, files) in walk(static_filepath):
+for pt, dirs, files in walk(static_filepath):
     for file in files:
         if ".html" in file:
             with open(path.join(static_filepath, file), "r") as f:

--- a/hatchet/writers/dataframe_writer.py
+++ b/hatchet/writers/dataframe_writer.py
@@ -64,9 +64,9 @@ class DataframeWriter(ABC):
         dump_df["inc_metrics"] = None
         dump_df.iat[0, dump_df.columns.get_loc("inc_metrics")] = gf_cpy.inc_metrics
         dump_df["default_metric"] = None
-        dump_df.iat[
-            0, dump_df.columns.get_loc("default_metric")
-        ] = gf_cpy.default_metric
+        dump_df.iat[0, dump_df.columns.get_loc("default_metric")] = (
+            gf_cpy.default_metric
+        )
         self._write_dataframe_to_file(dump_df, **kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "MIT"
 
 [tool.ruff]
 line-length = 88
-target-version = 'py37'
+target-version = 'py39'
 include = ['\.pyi?$']
 exclude = [
     ".eggs",
@@ -32,7 +32,7 @@ exclude = [
 
 [tool.black]
 line-length = 88
-target-version = ['py27', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ pandas
 pydot
 pytest
 codecov
-flake8
 pep8-naming
 numpy
 PyYAML


### PR DESCRIPTION
@draganagrbicllnl has been running into issues with `black` while trying to get formatting working in her PR #126. After looking at our CI, I realized we were using a 2.5 year old version of `black` with quite a few known bugs. The version of `black` we were using was particularly problematic since it was a beta version.

This PR upgrades `black` in CI to the newest version that supports our target Python version (3.9).