### PR TITLE
Hotfix: upgrades versions for GitHub Actions

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -18,19 +18,19 @@ jobs:
     name: Build wheels for Linux
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU to support non-x86 architectures
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
 
-      - uses: pypa/cibuildwheel@v2.12.1
+      - uses: pypa/cibuildwheel@v2
         env:
           CIBW_SKIP: pp* *musllinux*
           CIBW_ARCHS_LINUX: auto aarch64 ppc64le
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -71,7 +71,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get PyPA build
         run: python -m pip install build
@@ -92,12 +92,12 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -112,12 +112,12 @@ jobs:
     runs-on: ubuntu-20.04
     if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -24,12 +24,12 @@ jobs:
         hatchet-version: ["2022.2.0"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ format('v{0}', matrix.hatchet-version) }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,10 +20,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -61,7 +61,7 @@ jobs:
         pip install pytest-cov
 
     - name: Clone Caliper
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: LLNL/Caliper
         path: Caliper


### PR DESCRIPTION
This PR is a hotfix for an issue raised by the PyTorch team related to Hatchet not having Python 3.12 wheels on PyPI.

Since we autogenerate and autoupload our wheels using GitHub Actions, I reviewed the relevant `yaml` file and found that many of the Actions we were using were pinned to really old versions.

This PR simply upgrades GitHub Actions versions throughout all of our `yaml` files.