### PR TITLE
Allow tuple as Argument to tree

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -95,7 +95,7 @@ class ConsoleRenderer:
         else:
             self.colors = self.colors_disabled
 
-        if isinstance(self.metric_columns, str):
+        if isinstance(self.metric_columns, (str, tuple)):
             self.primary_metric = self.metric_columns
             self.second_metric = None
         elif isinstance(self.metric_columns, list):


### PR DESCRIPTION
As found in an earlier Slack discussion: in order to provide a single column to `GraphFrame.tree` in a MultiIndex `Thicket.statsframe` (GraphFrame), this small change is necessary.