### PR TITLE
Temporarily pin numpy Version Less Than 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pydot
 pytest
 codecov
 pep8-naming
-numpy
+numpy < 2.0.0
 PyYAML
 cython
 multiprocess

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         "pydot",
         "PyYAML",
         "matplotlib",
-        "numpy",
+        "numpy < 2.0.0",
         "pandas",
         "textX < 3.0.0; python_version < '3.6'",
         "textX >= 3.0.0; python_version >= '3.6'",


### PR DESCRIPTION
numpy recently released version [2.0](https://numpy.org/devdocs/release/2.0.0-notes.html) which has a lot of changes that break some of our unit tests.