### PR TITLE
Improves QL performance by changing how node data is accessed

### DIFF
--- a/hatchet/query/engine.py
+++ b/hatchet/query/engine.py
@@ -75,7 +75,7 @@ class QueryEngine:
             _, filter_func = node_query
             row = None
             if isinstance(dframe.index, pd.MultiIndex):
-                row = pd.concat([dframe.loc[node]], keys=[node], names=["node"])
+                row = dframe.xs(node, level="node", drop_level=False)
             else:
                 row = dframe.loc[node]
             if filter_func(row):


### PR DESCRIPTION
Using #142, I found a bottleneck in the QL logic for accessing data for a node when the dataframe uses a row `MultiIndex`. This PR changes that logic to use `pandas.DataFrame.xs`, resulting in a roughly 2x speedup in the code for node data access.