### PR TITLE
Ignore Error Message if Not IPython

### DIFF
--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -29,7 +29,7 @@ except ImportError:
     pass
 
 except VersionError:
-    if not isinstance(IPython.get_ipython(), type(None)):
+    if IPython.get_ipython() is not None:
         print(
             "Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x."
         )

--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -29,6 +29,7 @@ except ImportError:
     pass
 
 except VersionError:
-    print(
-        "Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x."
-    )
+    if not isinstance(IPython.get_ipython(), type(None)):
+        print(
+            "Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x."
+        )


### PR DESCRIPTION
https://github.com/LLNL/hatchet/pull/127 introduced a bug where the error message

```
Warning: Roundtrip module could not be loaded. Requires jupyter notebook version <= 7.x.
```

will always print if the `IPython` module is installed, even when running outside of `IPython`, such as when running hatchet in a terminal.

This PR fixes the bug by not printing the error message if [IPython is not registered](https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.getipython.html#IPython.core.getipython.get_ipython).