### PR TITLE
Enhancements to user interface when using QL with row MultiIndex

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -472,7 +472,7 @@ class GraphFrame:
         update_inc_cols=True,
         num_procs=mp.cpu_count(),
         rec_limit=1000,
-        multi_index_mode="off",
+        predicate_row_aggregator=None,
     ):
         """Filter the dataframe using a user-supplied function.
 
@@ -537,15 +537,17 @@ class GraphFrame:
             # If a raw Object-dialect query is provided (not already passed to ObjectQuery),
             # create a new ObjectQuery object.
             if isinstance(filter_obj, list):
-                query = ObjectQuery(filter_obj, multi_index_mode)
+                query = ObjectQuery(filter_obj)
             # If a raw String-dialect query is provided (not already passed to StringQuery),
             # create a new StringQuery object.
             elif isinstance(filter_obj, str):
-                query = parse_string_dialect(filter_obj, multi_index_mode)
+                query = parse_string_dialect(filter_obj)
             # If an old-style query is provided, extract the underlying new-style query.
             elif issubclass(type(filter_obj), AbstractQuery):
                 query = filter_obj._get_new_query()
-            query_matches = self.query_engine.apply(query, self.graph, self.dataframe)
+            query_matches = self.query_engine.apply(
+                query, self.graph, self.dataframe, predicate_row_aggregator
+            )
             # match_set = list(set().union(*query_matches))
             # filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(match_set)]
             filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(query_matches)]

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -495,7 +495,7 @@ class GraphFrame:
         if multi_index_mode is not None:
             warnings.warn(
                 "'multi_index_mode' parameter is deprecated. Use 'predicate_row_aggregator' instead",
-                DeprecationWarning
+                DeprecationWarning,
             )
             if predicate_row_aggregator is None:
                 predicate_row_aggregator = multi_index_mode

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -484,6 +484,10 @@ class GraphFrame:
             update_inc_cols (boolean, optional): if True, update inclusive columns when performing squash.
             rec_limit: set Python recursion limit, increase if running into
                 recursion depth errors) (default: 1000).
+            predicate_row_aggregator (str or Callable, optional): function to use in Query Language
+                to merge multiple predicate results for each node into a single boolean. When providing
+                a string value, the following are accepted: "all" (equivalent to Python 'all'), "any"
+                (equivalent to Python 'any'), "off" (no aggregation)
         """
         sys.setrecursionlimit(rec_limit)
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -8,6 +8,7 @@ import json
 import sys
 import traceback
 from collections import defaultdict
+import warnings
 
 import multiprocess as mp
 import numpy as np
@@ -473,6 +474,7 @@ class GraphFrame:
         num_procs=mp.cpu_count(),
         rec_limit=1000,
         predicate_row_aggregator=None,
+        multi_index_mode=None,
     ):
         """Filter the dataframe using a user-supplied function.
 
@@ -488,7 +490,16 @@ class GraphFrame:
                 to merge multiple predicate results for each node into a single boolean. When providing
                 a string value, the following are accepted: "all" (equivalent to Python 'all'), "any"
                 (equivalent to Python 'any'), "off" (no aggregation)
+            multi_index_mode: deprecated alias for "predicate_row_aggregator"
         """
+        if multi_index_mode is not None:
+            warnings.warn(
+                "'multi_index_mode' parameter is deprecated. Use 'predicate_row_aggregator' instead",
+                DeprecationWarning
+            )
+            if predicate_row_aggregator is None:
+                predicate_row_aggregator = multi_index_mode
+
         sys.setrecursionlimit(rec_limit)
 
         dataframe_copy = self.dataframe.copy()

--- a/hatchet/query/compat.py
+++ b/hatchet/query/compat.py
@@ -125,7 +125,7 @@ class NaryQuery(AbstractQuery):
             (list): A list of nodes representing the result of the query
         """
         true_query = self._get_new_query()
-        return COMPATABILITY_ENGINE.apply(true_query, gf.graph, gf.dataframe)
+        return COMPATABILITY_ENGINE.apply(true_query, gf.graph, gf.dataframe, "off")
 
     def _get_new_query(self):
         """Gets all the underlying 'new-style' queries in this object.
@@ -322,7 +322,7 @@ class QueryMatcher(AbstractQuery):
         Returns:
             (list): A list representing the set of nodes from paths that match this query
         """
-        return COMPATABILITY_ENGINE.apply(self.true_query, gf.graph, gf.dataframe)
+        return COMPATABILITY_ENGINE.apply(self.true_query, gf.graph, gf.dataframe, "off")
 
     def _get_new_query(self):
         """Get all the underlying 'new-style' query in this object.

--- a/hatchet/query/compat.py
+++ b/hatchet/query/compat.py
@@ -322,7 +322,9 @@ class QueryMatcher(AbstractQuery):
         Returns:
             (list): A list representing the set of nodes from paths that match this query
         """
-        return COMPATABILITY_ENGINE.apply(self.true_query, gf.graph, gf.dataframe, "off")
+        return COMPATABILITY_ENGINE.apply(
+            self.true_query, gf.graph, gf.dataframe, "off"
+        )
 
     def _get_new_query(self):
         """Get all the underlying 'new-style' query in this object.

--- a/hatchet/query/engine.py
+++ b/hatchet/query/engine.py
@@ -57,17 +57,17 @@ class QueryEngine:
             aggregator = predicate_row_aggregator
             if predicate_row_aggregator is None:
                 aggregator = query.default_aggregator
-            if predicate_row_aggregator == "all":
+            if aggregator == "all":
                 aggregator = _all_aggregator
-            elif predicate_row_aggregator == "any":
+            elif aggregator == "any":
                 aggregator = _any_aggregator
-            elif predicate_row_aggregator == "off":
+            elif aggregator == "off":
                 if isinstance(dframe.index, pd.MultiIndex):
                     raise ValueError(
                         "'predicate_row_aggregator' cannot be 'off' when the DataFrame has a row multi-index"
                     )
                 aggregator = None
-            elif not callable(predicate_row_aggregator):
+            elif not callable(aggregator):
                 raise ValueError(
                     "Invalid value provided for 'predicate_row_aggregator'"
                 )

--- a/hatchet/query/engine.py
+++ b/hatchet/query/engine.py
@@ -57,7 +57,7 @@ class QueryEngine:
             aggregator = predicate_row_aggregator
             if predicate_row_aggregator is None:
                 aggregator = query.default_aggregator
-            elif predicate_row_aggregator == "all":
+            if predicate_row_aggregator == "all":
                 aggregator = _all_aggregator
             elif predicate_row_aggregator == "any":
                 aggregator = _any_aggregator

--- a/hatchet/query/engine.py
+++ b/hatchet/query/engine.py
@@ -301,7 +301,7 @@ class QueryEngine:
         # this node.
         if query.query_pattern[0][0] == "*":
             if 1 in self.search_cache[node._hatchet_nid]:
-                sub_match = self._match_pattern(query, dframe, node, 1)
+                sub_match = self._match_pattern(query, dframe, predicate_row_aggregator, node, 1)
                 if sub_match is not None:
                     matches.extend(sub_match)
         if 0 in self.search_cache[node._hatchet_nid]:

--- a/hatchet/query/engine.py
+++ b/hatchet/query/engine.py
@@ -301,7 +301,9 @@ class QueryEngine:
         # this node.
         if query.query_pattern[0][0] == "*":
             if 1 in self.search_cache[node._hatchet_nid]:
-                sub_match = self._match_pattern(query, dframe, predicate_row_aggregator, node, 1)
+                sub_match = self._match_pattern(
+                    query, dframe, predicate_row_aggregator, node, 1
+                )
                 if sub_match is not None:
                     matches.extend(sub_match)
         if 0 in self.search_cache[node._hatchet_nid]:

--- a/hatchet/query/errors.py
+++ b/hatchet/query/errors.py
@@ -18,9 +18,3 @@ class RedundantQueryFilterWarning(Warning):
 
 class BadNumberNaryQueryArgs(Exception):
     """Raised when a query filter does not have a valid syntax"""
-
-
-class MultiIndexModeMismatch(Exception):
-    """Raised when an ObjectQuery or StringQuery object
-    is set to use multi-indexed data, but no multi-indexed
-    data is provided"""

--- a/hatchet/query/object_dialect.py
+++ b/hatchet/query/object_dialect.py
@@ -17,17 +17,7 @@ from .errors import InvalidQueryPath, InvalidQueryFilter, MultiIndexModeMismatch
 from .query import Query
 
 
-def _process_multi_index_mode(apply_result, multi_index_mode):
-    if multi_index_mode == "any":
-        return apply_result.any()
-    if multi_index_mode == "all":
-        return apply_result.all()
-    raise ValueError(
-        "Multi-Index Mode for the Object-based dialect must be either 'any' or 'all'"
-    )
-
-
-def _process_predicate(attr_filter, multi_index_mode):
+def _process_predicate(attr_filter):
     """Converts high-level API attribute filter to a lambda"""
     compops = ("<", ">", "==", ">=", "<=", "<>", "!=")  # ,
 
@@ -126,12 +116,6 @@ def _process_predicate(attr_filter, multi_index_mode):
         return matches
 
     def filter_dframe(df_row):
-        if multi_index_mode == "off":
-            raise MultiIndexModeMismatch(
-                "The ObjectQuery's 'multi_index_mode' argument \
-                cannot be set to 'off' when using multi-indexed data"
-            )
-
         def filter_single_dframe(node, df_row, key, single_value):
             if key == "depth":
                 if isinstance(single_value, str) and single_value.lower().startswith(
@@ -164,21 +148,18 @@ def _process_predicate(attr_filter, multi_index_mode):
                     raise InvalidQueryFilter(
                         "Value for attribute {} must be a string.".format(key)
                     )
-                apply_ret = df_row[key].apply(
+                return df_row[key].apply(
                     lambda x: re.match(single_value + r"\Z", x) is not None
                 )
-                return _process_multi_index_mode(apply_ret, multi_index_mode)
             if is_numeric_dtype(df_row[key]):
                 if isinstance(single_value, str) and single_value.lower().startswith(
                     compops
                 ):
-                    apply_ret = df_row[key].apply(
+                    return df_row[key].apply(
                         lambda x: eval("{} {}".format(x, single_value))
                     )
-                    return _process_multi_index_mode(apply_ret, multi_index_mode)
                 if isinstance(single_value, Real):
-                    apply_ret = df_row[key].apply(lambda x: x == single_value).any()
-                    return _process_multi_index_mode(apply_ret, multi_index_mode)
+                    return df_row[key].apply(lambda x: x == single_value).any()
                 raise InvalidQueryFilter(
                     "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
                         key
@@ -218,7 +199,7 @@ def _process_predicate(attr_filter, multi_index_mode):
 class ObjectQuery(Query):
     """Class for representing and parsing queries using the Object-based dialect."""
 
-    def __init__(self, query, multi_index_mode="off"):
+    def __init__(self, query):
         """Builds a new ObjectQuery from an instance of the Object-based dialect syntax.
 
         Arguments:
@@ -229,18 +210,15 @@ class ObjectQuery(Query):
         else:
             super().__init__()
         assert isinstance(query, list)
-        assert multi_index_mode in ["off", "all", "any"]
         for qnode in query:
             if isinstance(qnode, dict):
-                self._add_node(predicate=_process_predicate(qnode, multi_index_mode))
+                self._add_node(predicate=_process_predicate(qnode))
             elif isinstance(qnode, str) or isinstance(qnode, int):
                 self._add_node(quantifer=qnode)
             elif isinstance(qnode, tuple):
                 assert isinstance(qnode[1], dict)
                 if isinstance(qnode[0], str) or isinstance(qnode[0], int):
-                    self._add_node(
-                        qnode[0], _process_predicate(qnode[1], multi_index_mode)
-                    )
+                    self._add_node(qnode[0], _process_predicate(qnode[1]))
                 else:
                     raise InvalidQueryPath(
                         "The first value of a tuple entry in a path must be either a string or integer."
@@ -249,3 +227,4 @@ class ObjectQuery(Query):
                 raise InvalidQueryPath(
                     "A query path must be a list containing String, Integer, Dict, or Tuple elements"
                 )
+        self.default_aggregator = "all"

--- a/hatchet/query/object_dialect.py
+++ b/hatchet/query/object_dialect.py
@@ -13,7 +13,7 @@ from pandas.api.types import (
 import re
 import sys
 
-from .errors import InvalidQueryPath, InvalidQueryFilter, MultiIndexModeMismatch
+from .errors import InvalidQueryPath, InvalidQueryFilter
 from .query import Query
 
 

--- a/hatchet/query/query.py
+++ b/hatchet/query/query.py
@@ -12,6 +12,7 @@ class Query(object):
     def __init__(self):
         """Create new Query"""
         self.query_pattern = []
+        self.default_aggregator = "off"
 
     def match(self, quantifier=".", predicate=lambda row: True):
         """Start a query with a root node described by the arguments.

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -530,7 +530,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -553,7 +555,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -596,7 +600,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -619,7 +625,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -662,7 +670,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -685,7 +695,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -728,7 +740,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -751,7 +765,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -794,7 +810,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -817,7 +835,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -1404,7 +1404,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [

--- a/hatchet/query/string_dialect.py
+++ b/hatchet/query/string_dialect.py
@@ -739,7 +739,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -762,7 +764,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -811,7 +815,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -834,7 +840,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -879,7 +887,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -902,7 +912,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -944,7 +956,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -967,7 +981,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1012,7 +1028,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1035,7 +1053,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1077,7 +1097,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1100,7 +1122,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1145,7 +1169,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1168,7 +1194,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1210,7 +1238,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1233,7 +1263,9 @@ class StringQuery(Query):
                     This condition will always be false.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1278,7 +1310,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1301,7 +1335,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [
@@ -1343,7 +1379,9 @@ class StringQuery(Query):
                     This condition will always be true.
                     The statement that triggered this warning is:
                     {}
-                    """.format(obj),
+                    """.format(
+                        obj
+                    ),
                     RedundantQueryFilterWarning,
                 )
                 return [

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -513,7 +513,9 @@ def test_apply_indices(calc_pi_hpct_db):
     matches = list(set().union(*matches))
     query = ObjectQuery(path)
     engine = QueryEngine()
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+    ) == sorted(matches)
 
     gf.drop_index_levels()
     assert engine.apply(query, gf.graph, gf.dataframe) == matches
@@ -598,11 +600,16 @@ def test_object_dialect_depth_index_levels(calc_pi_hpct_db):
         [root.children[0].children[1]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+    ) == sorted(matches)
 
     query = ObjectQuery([("*", {"depth": 0})])
     matches = [root]
-    assert engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all") == matches
+    assert (
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+        == matches
+    )
 
     with pytest.raises(InvalidQueryFilter):
         query = ObjectQuery([{"depth": "hello"}])
@@ -623,11 +630,16 @@ def test_object_dialect_node_id_index_levels(calc_pi_hpct_db):
         [root.children[0].children[0]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+    ) == sorted(matches)
 
     query = ObjectQuery([("*", {"node_id": 0})])
     matches = [root]
-    assert engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all") == matches
+    assert (
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+        == matches
+    )
 
     with pytest.raises(InvalidQueryFilter):
         query = ObjectQuery([{"node_id": "hello"}])
@@ -1281,9 +1293,7 @@ def test_leaf_query(small_mock2):
 def test_object_dialect_all_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
-    query = ObjectQuery(
-        [".", ("+", {"time (inc)": ">= 17983.0"})]
-    )
+    query = ObjectQuery([".", ("+", {"time (inc)": ">= 17983.0"})])
     roots = gf.graph.roots
     matches = [
         roots[0],
@@ -1291,7 +1301,9 @@ def test_object_dialect_all_mode(tau_profile_dir):
         roots[0].children[6].children[1],
         roots[0].children[0],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+    ) == sorted(matches)
 
 
 def test_string_dialect_all_mode(tau_profile_dir):
@@ -1309,7 +1321,9 @@ def test_string_dialect_all_mode(tau_profile_dir):
         roots[0].children[6].children[1],
         roots[0].children[0],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
+    ) == sorted(matches)
 
 
 def test_object_dialect_any_mode(tau_profile_dir):
@@ -1321,7 +1335,9 @@ def test_object_dialect_any_mode(tau_profile_dir):
         roots[0].children[2],
         roots[0].children[6].children[3],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="any")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="any")
+    ) == sorted(matches)
 
 
 def test_string_dialect_any_mode(tau_profile_dir):
@@ -1337,7 +1353,9 @@ def test_string_dialect_any_mode(tau_profile_dir):
         roots[0].children[2],
         roots[0].children[6].children[3],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="any")) == sorted(matches)
+    assert sorted(
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="any")
+    ) == sorted(matches)
 
 
 def test_predicate_row_aggregator_assertion_error(tau_profile_dir):
@@ -1346,8 +1364,6 @@ def test_predicate_row_aggregator_assertion_error(tau_profile_dir):
     query = ObjectQuery([".", ("*", {"name": "test"})])
     with pytest.raises(ValueError):
         engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="foo")
-    query = ObjectQuery(
-        [".", ("*", {"time (inc)": "> 17983.0"})]
-    )
+    query = ObjectQuery([".", ("*", {"time (inc)": "> 17983.0"})])
     with pytest.raises(ValueError):
         engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="off")

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -401,9 +401,9 @@ def test_apply(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
-        "list"
-    ] = DummyType()
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
+        DummyType()
+    )
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     query = ObjectQuery(path)
@@ -512,7 +512,7 @@ def test_apply_indices(calc_pi_hpct_db):
         ],
     ]
     matches = list(set().union(*matches))
-    query = ObjectQuery(path, multi_index_mode="all")
+    query = ObjectQuery(path, predicate_row_aggregator="all")
     engine = QueryEngine()
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
 
@@ -588,7 +588,7 @@ def test_object_dialect_depth_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
     root = gf.graph.roots[0]
 
-    query = ObjectQuery([("*", {"depth": "<= 2"})], multi_index_mode="all")
+    query = ObjectQuery([("*", {"depth": "<= 2"})], predicate_row_aggregator="all")
     engine = QueryEngine()
     matches = [
         [root, root.children[0], root.children[0].children[0]],
@@ -601,12 +601,12 @@ def test_object_dialect_depth_index_levels(calc_pi_hpct_db):
     matches = list(set().union(*matches))
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
 
-    query = ObjectQuery([("*", {"depth": 0})], multi_index_mode="all")
+    query = ObjectQuery([("*", {"depth": 0})], predicate_row_aggregator="all")
     matches = [root]
     assert engine.apply(query, gf.graph, gf.dataframe) == matches
 
     with pytest.raises(InvalidQueryFilter):
-        query = ObjectQuery([{"depth": "hello"}], multi_index_mode="all")
+        query = ObjectQuery([{"depth": "hello"}], predicate_row_aggregator="all")
         engine.apply(query, gf.graph, gf.dataframe)
 
 
@@ -614,7 +614,7 @@ def test_object_dialect_node_id_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
     root = gf.graph.roots[0]
 
-    query = ObjectQuery([("*", {"node_id": "<= 2"})], multi_index_mode="all")
+    query = ObjectQuery([("*", {"node_id": "<= 2"})], predicate_row_aggregator="all")
     engine = QueryEngine()
     matches = [
         [root, root.children[0]],
@@ -626,12 +626,12 @@ def test_object_dialect_node_id_index_levels(calc_pi_hpct_db):
     matches = list(set().union(*matches))
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
 
-    query = ObjectQuery([("*", {"node_id": 0})], multi_index_mode="all")
+    query = ObjectQuery([("*", {"node_id": 0})], predicate_row_aggregator="all")
     matches = [root]
     assert engine.apply(query, gf.graph, gf.dataframe) == matches
 
     with pytest.raises(InvalidQueryFilter):
-        query = ObjectQuery([{"node_id": "hello"}], multi_index_mode="all")
+        query = ObjectQuery([{"node_id": "hello"}], predicate_row_aggregator="all")
         engine.apply(query, gf.graph, gf.dataframe)
 
 
@@ -1028,9 +1028,9 @@ def test_apply_string_dialect(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
-        "list"
-    ] = DummyType()
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
+        DummyType()
+    )
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()
@@ -1283,7 +1283,7 @@ def test_object_dialect_all_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
     query = ObjectQuery(
-        [".", ("+", {"time (inc)": ">= 17983.0"})], multi_index_mode="all"
+        [".", ("+", {"time (inc)": ">= 17983.0"})], predicate_row_aggregator="all"
     )
     roots = gf.graph.roots
     matches = [
@@ -1302,7 +1302,7 @@ def test_string_dialect_all_mode(tau_profile_dir):
         """MATCH (".")->("+", p)
         WHERE p."time (inc)" >= 17983.0
         """,
-        multi_index_mode="all",
+        predicate_row_aggregator="all",
     )
     roots = gf.graph.roots
     matches = [
@@ -1317,7 +1317,7 @@ def test_string_dialect_all_mode(tau_profile_dir):
 def test_object_dialect_any_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
-    query = ObjectQuery([{"time": "< 24.0"}], multi_index_mode="any")
+    query = ObjectQuery([{"time": "< 24.0"}], predicate_row_aggregator="any")
     roots = gf.graph.roots
     matches = [
         roots[0].children[2],
@@ -1333,7 +1333,7 @@ def test_string_dialect_any_mode(tau_profile_dir):
         """MATCH (".", p)
         WHERE p."time" < 24.0
         """,
-        multi_index_mode="any",
+        predicate_row_aggregator="any",
     )
     roots = gf.graph.roots
     matches = [
@@ -1343,19 +1343,19 @@ def test_string_dialect_any_mode(tau_profile_dir):
     assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
 
 
-def test_multi_index_mode_assertion_error(tau_profile_dir):
+def test_predicate_row_aggregator_assertion_error(tau_profile_dir):
     with pytest.raises(AssertionError):
-        _ = ObjectQuery([".", ("*", {"name": "test"})], multi_index_mode="foo")
+        _ = ObjectQuery([".", ("*", {"name": "test"})], predicate_row_aggregator="foo")
     with pytest.raises(AssertionError):
         _ = StringQuery(
             """ MATCH (".")->("*", p)
             WHERE p."name" = "test"
             """,
-            multi_index_mode="foo",
+            predicate_row_aggregator="foo",
         )
     gf = GraphFrame.from_tau(tau_profile_dir)
     query = ObjectQuery(
-        [".", ("*", {"time (inc)": "> 17983.0"})], multi_index_mode="off"
+        [".", ("*", {"time (inc)": "> 17983.0"})], predicate_row_aggregator="off"
     )
     engine = QueryEngine()
     with pytest.raises(MultiIndexModeMismatch):

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -287,9 +287,9 @@ def test_match_1(mock_graph_literal):
     query = ObjectQuery(path)
     engine = QueryEngine()
 
-    assert engine._match_1(query, gf.dataframe, None, gf.graph.roots[0].children[0], 2) == [
-        [gf.graph.roots[0].children[0].children[1]]
-    ]
+    assert engine._match_1(
+        query, gf.dataframe, None, gf.graph.roots[0].children[0], 2
+    ) == [[gf.graph.roots[0].children[0].children[1]]]
     assert engine._match_1(query, gf.dataframe, None, gf.graph.roots[0], 2) is None
 
 

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -238,7 +238,7 @@ def test_node_caching(mock_graph_literal):
 
     query = ObjectQuery(path)
     engine = QueryEngine()
-    engine._cache_node(node, query, gf.dataframe)
+    engine._cache_node(node, query, gf.dataframe, None)
 
     assert 0 in engine.search_cache[node._hatchet_nid]
     assert 1 in engine.search_cache[node._hatchet_nid]
@@ -269,12 +269,12 @@ def test_match_0_or_more_wildcard(mock_graph_literal):
     engine = QueryEngine()
     matched_paths = []
     for child in sorted(node.children, key=traversal_order):
-        match = engine._match_0_or_more(query, gf.dataframe, child, 1)
+        match = engine._match_0_or_more(query, gf.dataframe, None, child, 1)
         if match is not None:
             matched_paths.extend(match)
 
     assert sorted(matched_paths, key=len) == sorted(correct_paths, key=len)
-    assert engine._match_0_or_more(query, gf.dataframe, none_node, 1) is None
+    assert engine._match_0_or_more(query, gf.dataframe, None, none_node, 1) is None
 
 
 def test_match_1(mock_graph_literal):
@@ -287,10 +287,10 @@ def test_match_1(mock_graph_literal):
     query = ObjectQuery(path)
     engine = QueryEngine()
 
-    assert engine._match_1(query, gf.dataframe, gf.graph.roots[0].children[0], 2) == [
+    assert engine._match_1(query, gf.dataframe, None, gf.graph.roots[0].children[0], 2) == [
         [gf.graph.roots[0].children[0].children[1]]
     ]
-    assert engine._match_1(query, gf.dataframe, gf.graph.roots[0], 2) is None
+    assert engine._match_1(query, gf.dataframe, None, gf.graph.roots[0], 2) is None
 
 
 def test_match(mock_graph_literal):

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -401,9 +401,9 @@ def test_apply(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
-        DummyType()
-    )
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
+        "list"
+    ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     query = ObjectQuery(path)
@@ -1028,9 +1028,9 @@ def test_apply_string_dialect(mock_graph_literal):
             self.z = "hello"
 
     bad_field_test_dict = list(mock_graph_literal)
-    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"]["list"] = (
-        DummyType()
-    )
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
+        "list"
+    ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
     path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -25,7 +25,6 @@ from hatchet.query import (
     ExclusiveDisjunctionQuery,
     NegationQuery,
 )
-from hatchet.query.errors import MultiIndexModeMismatch
 
 
 def test_construct_object_dialect():
@@ -512,9 +511,9 @@ def test_apply_indices(calc_pi_hpct_db):
         ],
     ]
     matches = list(set().union(*matches))
-    query = ObjectQuery(path, predicate_row_aggregator="all")
+    query = ObjectQuery(path)
     engine = QueryEngine()
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
 
     gf.drop_index_levels()
     assert engine.apply(query, gf.graph, gf.dataframe) == matches
@@ -588,7 +587,7 @@ def test_object_dialect_depth_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
     root = gf.graph.roots[0]
 
-    query = ObjectQuery([("*", {"depth": "<= 2"})], predicate_row_aggregator="all")
+    query = ObjectQuery([("*", {"depth": "<= 2"})])
     engine = QueryEngine()
     matches = [
         [root, root.children[0], root.children[0].children[0]],
@@ -599,22 +598,22 @@ def test_object_dialect_depth_index_levels(calc_pi_hpct_db):
         [root.children[0].children[1]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
 
-    query = ObjectQuery([("*", {"depth": 0})], predicate_row_aggregator="all")
+    query = ObjectQuery([("*", {"depth": 0})])
     matches = [root]
-    assert engine.apply(query, gf.graph, gf.dataframe) == matches
+    assert engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all") == matches
 
     with pytest.raises(InvalidQueryFilter):
-        query = ObjectQuery([{"depth": "hello"}], predicate_row_aggregator="all")
-        engine.apply(query, gf.graph, gf.dataframe)
+        query = ObjectQuery([{"depth": "hello"}])
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
 
 
 def test_object_dialect_node_id_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
     root = gf.graph.roots[0]
 
-    query = ObjectQuery([("*", {"node_id": "<= 2"})], predicate_row_aggregator="all")
+    query = ObjectQuery([("*", {"node_id": "<= 2"})])
     engine = QueryEngine()
     matches = [
         [root, root.children[0]],
@@ -624,15 +623,15 @@ def test_object_dialect_node_id_index_levels(calc_pi_hpct_db):
         [root.children[0].children[0]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
 
-    query = ObjectQuery([("*", {"node_id": 0})], predicate_row_aggregator="all")
+    query = ObjectQuery([("*", {"node_id": 0})])
     matches = [root]
-    assert engine.apply(query, gf.graph, gf.dataframe) == matches
+    assert engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all") == matches
 
     with pytest.raises(InvalidQueryFilter):
-        query = ObjectQuery([{"node_id": "hello"}], predicate_row_aggregator="all")
-        engine.apply(query, gf.graph, gf.dataframe)
+        query = ObjectQuery([{"node_id": "hello"}])
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")
 
 
 def test_object_dialect_multi_condition_one_attribute(mock_graph_literal):
@@ -1283,7 +1282,7 @@ def test_object_dialect_all_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
     query = ObjectQuery(
-        [".", ("+", {"time (inc)": ">= 17983.0"})], predicate_row_aggregator="all"
+        [".", ("+", {"time (inc)": ">= 17983.0"})]
     )
     roots = gf.graph.roots
     matches = [
@@ -1292,7 +1291,7 @@ def test_object_dialect_all_mode(tau_profile_dir):
         roots[0].children[6].children[1],
         roots[0].children[0],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
 
 
 def test_string_dialect_all_mode(tau_profile_dir):
@@ -1301,8 +1300,7 @@ def test_string_dialect_all_mode(tau_profile_dir):
     query = StringQuery(
         """MATCH (".")->("+", p)
         WHERE p."time (inc)" >= 17983.0
-        """,
-        predicate_row_aggregator="all",
+        """
     )
     roots = gf.graph.roots
     matches = [
@@ -1311,19 +1309,19 @@ def test_string_dialect_all_mode(tau_profile_dir):
         roots[0].children[6].children[1],
         roots[0].children[0],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="all")) == sorted(matches)
 
 
 def test_object_dialect_any_mode(tau_profile_dir):
     gf = GraphFrame.from_tau(tau_profile_dir)
     engine = QueryEngine()
-    query = ObjectQuery([{"time": "< 24.0"}], predicate_row_aggregator="any")
+    query = ObjectQuery([{"time": "< 24.0"}])
     roots = gf.graph.roots
     matches = [
         roots[0].children[2],
         roots[0].children[6].children[3],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="any")) == sorted(matches)
 
 
 def test_string_dialect_any_mode(tau_profile_dir):
@@ -1332,31 +1330,24 @@ def test_string_dialect_any_mode(tau_profile_dir):
     query = StringQuery(
         """MATCH (".", p)
         WHERE p."time" < 24.0
-        """,
-        predicate_row_aggregator="any",
+        """
     )
     roots = gf.graph.roots
     matches = [
         roots[0].children[2],
         roots[0].children[6].children[3],
     ]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="any")) == sorted(matches)
 
 
 def test_predicate_row_aggregator_assertion_error(tau_profile_dir):
-    with pytest.raises(AssertionError):
-        _ = ObjectQuery([".", ("*", {"name": "test"})], predicate_row_aggregator="foo")
-    with pytest.raises(AssertionError):
-        _ = StringQuery(
-            """ MATCH (".")->("*", p)
-            WHERE p."name" = "test"
-            """,
-            predicate_row_aggregator="foo",
-        )
     gf = GraphFrame.from_tau(tau_profile_dir)
-    query = ObjectQuery(
-        [".", ("*", {"time (inc)": "> 17983.0"})], predicate_row_aggregator="off"
-    )
     engine = QueryEngine()
-    with pytest.raises(MultiIndexModeMismatch):
-        engine.apply(query, gf.graph, gf.dataframe)
+    query = ObjectQuery([".", ("*", {"name": "test"})])
+    with pytest.raises(ValueError):
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="foo")
+    query = ObjectQuery(
+        [".", ("*", {"time (inc)": "> 17983.0"})]
+    )
+    with pytest.raises(ValueError):
+        engine.apply(query, gf.graph, gf.dataframe, predicate_row_aggregator="off")

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -315,7 +315,7 @@ def test_match(mock_graph_literal):
     ]
     query0 = ObjectQuery(path0)
     engine = QueryEngine()
-    assert engine._match_pattern(query0, gf.dataframe, root, 0) == match0
+    assert engine._match_pattern(query0, gf.dataframe, query0.default_aggregator, root, 0) == match0
 
     engine.reset_cache()
 
@@ -327,7 +327,7 @@ def test_match(mock_graph_literal):
         {"time (inc)": 7.5, "time": 7.5},
     ]
     query1 = ObjectQuery(path1)
-    assert engine._match_pattern(query1, gf.dataframe, root, 0) is None
+    assert engine._match_pattern(query1, gf.dataframe, query0.default_aggregator, root, 0) is None
 
 
 def test_apply(mock_graph_literal):
@@ -349,7 +349,7 @@ def test_apply(mock_graph_literal):
     query = ObjectQuery(path)
     engine = QueryEngine()
 
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = [{"time (inc)": ">= 30.0"}, ".", {"name": "bar"}, "*"]
     match = [
@@ -360,12 +360,12 @@ def test_apply(mock_graph_literal):
         root.children[1].children[0].children[0].children[0].children[1],
     ]
     query = ObjectQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
     match = [root, root.children[0], root.children[0].children[0]]
     query = ObjectQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = [{"name": "foo"}, {"name": "qux"}, ("+", {"time (inc)": "> 15.0"})]
     match = [
@@ -376,22 +376,22 @@ def test_apply(mock_graph_literal):
         root.children[1].children[0].children[0].children[0],
     ]
     query = ObjectQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
 
     query = ObjectQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == []
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == []
 
     path = [{"name": 5}, "*", {"name": "whatever"}]
     query = ObjectQuery(path)
     with pytest.raises(InvalidQueryFilter):
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
     path = [{"time": "badstring"}, "*", {"name": "whatever"}]
     query = ObjectQuery(path)
     with pytest.raises(InvalidQueryFilter):
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
     class DummyType:
         def __init__(self):
@@ -407,7 +407,7 @@ def test_apply(mock_graph_literal):
     path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
     query = ObjectQuery(path)
     with pytest.raises(InvalidQueryFilter):
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
     path = ["*", {"name": "bar"}, {"name": "grault"}, "*"]
     match = [
@@ -452,11 +452,11 @@ def test_apply(mock_graph_literal):
     ]
     match = list(set().union(*match))
     query = ObjectQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = ["*", {"name": "bar"}, {"name": "grault"}, "+"]
     query = ObjectQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == []
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == []
 
     # Test a former edge case with the + quantifier/wildcard
     match = [
@@ -486,7 +486,7 @@ def test_apply(mock_graph_literal):
     match = list(set().union(*match))
     path = [("+", {"name": "ba.*"})]
     query = ObjectQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
 
 def test_apply_indices(calc_pi_hpct_db):
@@ -518,7 +518,7 @@ def test_apply_indices(calc_pi_hpct_db):
     ) == sorted(matches)
 
     gf.drop_index_levels()
-    assert engine.apply(query, gf.graph, gf.dataframe) == matches
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == matches
 
 
 def test_object_dialect_depth(mock_graph_literal):
@@ -527,7 +527,7 @@ def test_object_dialect_depth(mock_graph_literal):
     engine = QueryEngine()
     roots = gf.graph.roots
     matches = [c for r in roots for c in r.children]
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(matches)
 
     query = ObjectQuery([("*", {"depth": "<= 2"})])
     matches = [
@@ -554,11 +554,11 @@ def test_object_dialect_depth(mock_graph_literal):
         [roots[1].children[0].children[1]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(matches)
 
     with pytest.raises(InvalidQueryFilter):
         query = ObjectQuery([{"depth": "hello"}])
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
 
 def test_object_dialect_hatchet_nid(mock_graph_literal):
@@ -575,14 +575,14 @@ def test_object_dialect_hatchet_nid(mock_graph_literal):
         [root.children[0].children[1]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(matches)
 
     query = ObjectQuery([{"node_id": 0}])
-    assert engine.apply(query, gf.graph, gf.dataframe) == [gf.graph.roots[0]]
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == [gf.graph.roots[0]]
 
     with pytest.raises(InvalidQueryFilter):
         query = ObjectQuery([{"node_id": "hello"}])
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
 
 def test_object_dialect_depth_index_levels(calc_pi_hpct_db):
@@ -702,7 +702,7 @@ def test_object_dialect_multi_condition_one_attribute(mock_graph_literal):
         [roots[1].children[0]],
     ]
     matches = list(set().union(*matches))
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(matches)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(matches)
 
 
 def test_obj_query_is_query():
@@ -799,7 +799,7 @@ def test_conjunction_query(mock_graph_literal):
         roots[0].children[1],
         roots[0].children[1].children[0],
     ]
-    assert sorted(engine.apply(compound_query, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
 
@@ -822,7 +822,7 @@ def test_disjunction_query(mock_graph_literal):
         roots[1].children[0].children[0],
         roots[1].children[0].children[1],
     ]
-    assert sorted(engine.apply(compound_query, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
 
@@ -841,7 +841,7 @@ def test_exc_disjunction_query(mock_graph_literal):
         roots[0].children[2].children[0].children[1].children[0].children[0],
         roots[1].children[0].children[0],
     ]
-    assert sorted(engine.apply(compound_query, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
 
@@ -963,7 +963,7 @@ def test_apply_string_dialect(mock_graph_literal):
     query = StringQuery(path)
     engine = QueryEngine()
 
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = """MATCH (p)->(".")->(q)->("*")
     WHERE p."time (inc)" >= 30.0 AND q."name" = "bar"
@@ -976,14 +976,14 @@ def test_apply_string_dialect(mock_graph_literal):
         root.children[1].children[0].children[0].children[0].children[1],
     ]
     query = StringQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = """MATCH (p)->(q)->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND r."time" = 5.0
     """
     match = [root, root.children[0], root.children[0].children[0]]
     query = StringQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = """MATCH (p)->(q)->("+", r)
     WHERE p."name" = "foo" AND q."name" = "qux" AND r."time (inc)" > 15.0
@@ -996,7 +996,7 @@ def test_apply_string_dialect(mock_graph_literal):
         root.children[1].children[0].children[0].children[0],
     ]
     query = StringQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = """MATCH (p)->(q)
     WHERE p."time (inc)" > 100 OR p."time (inc)" <= 30 AND q."time (inc)" = 20
@@ -1009,28 +1009,28 @@ def test_apply_string_dialect(mock_graph_literal):
         roots[1].children[0],
     ]
     query = StringQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = """MATCH (p)->("*", q)->(r)
     WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"
     """
 
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == []
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == []
 
     path = """MATCH (p)->("*")->(q)
     WHERE p."name" = 5 AND q."name" = "whatever"
     """
     with pytest.raises(InvalidQueryFilter):
         query = StringQuery(path)
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
     path = """MATCH (p)->("*")->(q)
     WHERE p."time" = "badstring" AND q."name" = "whatever"
     """
     query = StringQuery(path)
     with pytest.raises(InvalidQueryFilter):
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
     class DummyType:
         def __init__(self):
@@ -1048,7 +1048,7 @@ def test_apply_string_dialect(mock_graph_literal):
     """
     with pytest.raises(InvalidQueryPath):
         query = StringQuery(path)
-        engine.apply(query, gf.graph, gf.dataframe)
+        engine.apply(query, gf.graph, gf.dataframe, None)
 
     path = """MATCH ("*")->(p)->(q)->("*")
     WHERE p."name" = "bar" AND q."name" = "grault"
@@ -1095,13 +1095,13 @@ def test_apply_string_dialect(mock_graph_literal):
     ]
     match = list(set().union(*match))
     query = StringQuery(path)
-    assert sorted(engine.apply(query, gf.graph, gf.dataframe)) == sorted(match)
+    assert sorted(engine.apply(query, gf.graph, gf.dataframe, None)) == sorted(match)
 
     path = """MATCH ("*")->(p)->(q)->("+")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == []
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == []
 
     gf.dataframe["time"] = np.NaN
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
@@ -1109,7 +1109,7 @@ def test_apply_string_dialect(mock_graph_literal):
     WHERE p."time" IS NOT NAN"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == match
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == match
 
     gf.dataframe["time"] = 5.0
     gf.dataframe.at[gf.graph.roots[0], "time"] = np.NaN
@@ -1117,7 +1117,7 @@ def test_apply_string_dialect(mock_graph_literal):
     WHERE p."time" IS NAN"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == match
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == match
 
     gf.dataframe["time"] = np.Inf
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
@@ -1125,7 +1125,7 @@ def test_apply_string_dialect(mock_graph_literal):
     WHERE p."time" IS NOT INF"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == match
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == match
 
     gf.dataframe["time"] = 5.0
     gf.dataframe.at[gf.graph.roots[0], "time"] = np.Inf
@@ -1133,7 +1133,7 @@ def test_apply_string_dialect(mock_graph_literal):
     WHERE p."time" IS INF"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == match
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == match
 
     names = gf.dataframe["name"].copy()
     gf.dataframe["name"] = None
@@ -1142,7 +1142,7 @@ def test_apply_string_dialect(mock_graph_literal):
     WHERE p."name" IS NOT NONE"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == match
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == match
 
     gf.dataframe["name"] = names
     gf.dataframe.at[gf.graph.roots[0], "name"] = None
@@ -1150,7 +1150,7 @@ def test_apply_string_dialect(mock_graph_literal):
     WHERE p."name" IS NONE"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
-    assert engine.apply(query, gf.graph, gf.dataframe) == match
+    assert engine.apply(query, gf.graph, gf.dataframe, None) == match
 
 
 def test_string_conj_compound_query(mock_graph_literal):
@@ -1173,10 +1173,10 @@ def test_string_conj_compound_query(mock_graph_literal):
         roots[0].children[1],
         roots[0].children[1].children[0],
     ]
-    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
-    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
 
@@ -1208,10 +1208,10 @@ def test_string_disj_compound_query(mock_graph_literal):
         roots[1].children[0].children[0],
         roots[1].children[0].children[1],
     ]
-    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
-    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
 
@@ -1239,10 +1239,10 @@ def test_cypher_exc_disj_compound_query(mock_graph_literal):
         roots[0].children[2].children[0].children[1].children[0].children[0],
         roots[1].children[0].children[0],
     ]
-    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
-    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
 
@@ -1278,15 +1278,15 @@ def test_leaf_query(small_mock2):
         """
     )
     engine = QueryEngine()
-    assert sorted(engine.apply(obj_query, gf.graph, gf.dataframe)) == sorted(matches)
-    assert sorted(engine.apply(str_query_numeric, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(obj_query, gf.graph, gf.dataframe, None)) == sorted(matches)
+    assert sorted(engine.apply(str_query_numeric, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
-    assert sorted(engine.apply(str_query_is_leaf, gf.graph, gf.dataframe)) == sorted(
+    assert sorted(engine.apply(str_query_is_leaf, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
     assert sorted(
-        engine.apply(str_query_is_not_leaf, gf.graph, gf.dataframe)
+        engine.apply(str_query_is_not_leaf, gf.graph, gf.dataframe, None)
     ) == sorted(nonleaves)
 
 

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -316,7 +316,7 @@ def test_match(mock_graph_literal):
     query0 = ObjectQuery(path0)
     engine = QueryEngine()
     assert (
-        engine._match_pattern(query0, gf.dataframe, query0.default_aggregator, root, 0) 
+        engine._match_pattern(query0, gf.dataframe, query0.default_aggregator, root, 0)
         == match0
     )
 
@@ -331,7 +331,7 @@ def test_match(mock_graph_literal):
     ]
     query1 = ObjectQuery(path1)
     assert (
-        engine._match_pattern(query1, gf.dataframe, query0.default_aggregator, root, 0) 
+        engine._match_pattern(query1, gf.dataframe, query0.default_aggregator, root, 0)
         is None
     )
 

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -330,10 +330,7 @@ def test_match(mock_graph_literal):
         {"time (inc)": 7.5, "time": 7.5},
     ]
     query1 = ObjectQuery(path1)
-    assert (
-        engine._match_pattern(query1, gf.dataframe, _all_aggregator, root, 0)
-        is None
-    )
+    assert engine._match_pattern(query1, gf.dataframe, _all_aggregator, root, 0) is None
 
 
 def test_apply(mock_graph_literal):

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -315,7 +315,10 @@ def test_match(mock_graph_literal):
     ]
     query0 = ObjectQuery(path0)
     engine = QueryEngine()
-    assert engine._match_pattern(query0, gf.dataframe, query0.default_aggregator, root, 0) == match0
+    assert (
+        engine._match_pattern(query0, gf.dataframe, query0.default_aggregator, root, 0) 
+        == match0
+    )
 
     engine.reset_cache()
 
@@ -327,7 +330,10 @@ def test_match(mock_graph_literal):
         {"time (inc)": 7.5, "time": 7.5},
     ]
     query1 = ObjectQuery(path1)
-    assert engine._match_pattern(query1, gf.dataframe, query0.default_aggregator, root, 0) is None
+    assert (
+        engine._match_pattern(query1, gf.dataframe, query0.default_aggregator, root, 0) 
+        is None
+    )
 
 
 def test_apply(mock_graph_literal):
@@ -1173,12 +1179,12 @@ def test_string_conj_compound_query(mock_graph_literal):
         roots[0].children[1],
         roots[0].children[1].children[0],
     ]
-    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
-    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
+    assert sorted(
+        engine.apply(compound_query1, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
+    assert sorted(
+        engine.apply(compound_query2, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
 
 
 def test_string_disj_compound_query(mock_graph_literal):
@@ -1208,12 +1214,12 @@ def test_string_disj_compound_query(mock_graph_literal):
         roots[1].children[0].children[0],
         roots[1].children[0].children[1],
     ]
-    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
-    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
+    assert sorted(
+        engine.apply(compound_query1, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
+    assert sorted(
+        engine.apply(compound_query2, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
 
 
 def test_cypher_exc_disj_compound_query(mock_graph_literal):
@@ -1239,12 +1245,12 @@ def test_cypher_exc_disj_compound_query(mock_graph_literal):
         roots[0].children[2].children[0].children[1].children[0].children[0],
         roots[1].children[0].children[0],
     ]
-    assert sorted(engine.apply(compound_query1, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
-    assert sorted(engine.apply(compound_query2, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
+    assert sorted(
+        engine.apply(compound_query1, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
+    assert sorted(
+        engine.apply(compound_query2, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
 
 
 def test_leaf_query(small_mock2):
@@ -1278,13 +1284,15 @@ def test_leaf_query(small_mock2):
         """
     )
     engine = QueryEngine()
-    assert sorted(engine.apply(obj_query, gf.graph, gf.dataframe, None)) == sorted(matches)
-    assert sorted(engine.apply(str_query_numeric, gf.graph, gf.dataframe, None)) == sorted(
+    assert sorted(engine.apply(obj_query, gf.graph, gf.dataframe, None)) == sorted(
         matches
     )
-    assert sorted(engine.apply(str_query_is_leaf, gf.graph, gf.dataframe, None)) == sorted(
-        matches
-    )
+    assert sorted(
+        engine.apply(str_query_numeric, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
+    assert sorted(
+        engine.apply(str_query_is_leaf, gf.graph, gf.dataframe, None)
+    ) == sorted(matches)
     assert sorted(
         engine.apply(str_query_is_not_leaf, gf.graph, gf.dataframe, None)
     ) == sorted(nonleaves)

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -317,8 +317,7 @@ def test_match(mock_graph_literal):
     query0 = ObjectQuery(path0)
     engine = QueryEngine()
     assert (
-        engine._match_pattern(query0, gf.dataframe, _all_aggregator, root, 0)
-        == match0
+        engine._match_pattern(query0, gf.dataframe, _all_aggregator, root, 0) == match0
     )
 
     engine.reset_cache()

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -25,6 +25,7 @@ from hatchet.query import (
     ExclusiveDisjunctionQuery,
     NegationQuery,
 )
+from hatchet.query.engine import _all_aggregator, _any_aggregator
 
 
 def test_construct_object_dialect():
@@ -316,7 +317,7 @@ def test_match(mock_graph_literal):
     query0 = ObjectQuery(path0)
     engine = QueryEngine()
     assert (
-        engine._match_pattern(query0, gf.dataframe, query0.default_aggregator, root, 0)
+        engine._match_pattern(query0, gf.dataframe, _all_aggregator, root, 0)
         == match0
     )
 
@@ -331,7 +332,7 @@ def test_match(mock_graph_literal):
     ]
     query1 = ObjectQuery(path1)
     assert (
-        engine._match_pattern(query1, gf.dataframe, query0.default_aggregator, root, 0)
+        engine._match_pattern(query1, gf.dataframe, _all_aggregator, root, 0)
         is None
     )
 


### PR DESCRIPTION
In #76, I added a new `multi_index_mode` parameter to `GraphFrame.filter` and the query language to allow us to apply queries to GraphFrames where we have a row `MultiIndex`. However, since then, there's been a lot of confusion about the parameter, what is does, and how to use it, especially in Thicket.

This PR improves naming, simplifies default use, and enhances functionality of this feature. More specifically, this PR does 3 things:
1. Renames `multi_index_mode` to `predicate_row_aggregator`, which more clearly indicates that the argument is used to aggregate per-row outputs from predicates
2. Expands the acceptable values to `predicate_row_aggregator`
3. Adds a new mechanism that allows the query classes (i.e., `Query`, `ObjectQuery`, `StringQuery`) to define a default aggregator
4. Moves logic for applying aggregators to `QueryEngine`, which allows us to bypass all of this if we don't have a row `MultiIndex`

With this PR, the `predicate_row_aggregator` argument now accepts the following:
* `None`: tells Hatchet to use the default aggregator for the type of query
* `"off"`: tells Hatchet to not use any aggregators (note: this will result in errors if there is a row `MultiIndex`)
* `"all"`: applies an aggregator that returns true if and only if the predicate returned true for *all* rows associated with a node
* `"any"`: applies an aggregator that returns true if the predicate returned true for *any* row associated with a node
* Callable that takes a `pandas.Series` of booleans as input and returns a boolean as output: applies the user-provided function as an aggregator

When using `predicate_row_aggregator=None`, the aggregators used will be:
* `"off"` if using a base syntax query (corresponds to the `Query` class)
* `"all"` if using a object or string dialect query (corresponds to the `ObjectQuery` and `StringQuery` classes)
* the default aggregators for each subquery if using a compound query