### PR TITLE
Fix Node Ordering Setting

### DIFF
--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -216,6 +216,10 @@ class Graph:
         if old_to_new is None:
             old_to_new = {}  # mapping from old nodes to new nodes
 
+        def key(n):
+            """Sort nodes by hatchet nid if node_ordering enabled, otherwise sort by frame."""
+            return n._hatchet_nid if self.node_ordering else n.frame
+
         def _merge(self_children, other_children, parent):
             """Recursively merge children of self and other.
 
@@ -258,7 +262,7 @@ class Graph:
                     if not new_node:
                         new_node = make_node(self_child)
                         _merge(
-                            sorted(self_child.children, key=lambda n: n.frame),
+                            sorted(self_child.children, key=key),
                             (),
                             new_node,
                         )
@@ -272,7 +276,7 @@ class Graph:
                         new_node = make_node(other_child)
                         _merge(
                             (),
-                            sorted(other_child.children, key=lambda n: n.frame),
+                            sorted(other_child.children, key=key),
                             new_node,
                         )
                     connect(parent, new_node)
@@ -301,8 +305,8 @@ class Graph:
                         other_side = []
 
                     _merge(
-                        sorted(self_side, key=lambda n: n.frame),
-                        sorted(other_side, key=lambda n: n.frame),
+                        sorted(self_side, key=key),
+                        sorted(other_side, key=key),
                         new_node,
                     )
 
@@ -316,7 +320,7 @@ class Graph:
                 if not new_node:
                     new_node = make_node(self_child)
                     _merge(
-                        sorted(self_child.children, key=lambda n: n.frame),
+                        sorted(self_child.children, key=key),
                         (),
                         new_node,
                     )
@@ -329,7 +333,7 @@ class Graph:
                     new_node = make_node(other_child)
                     _merge(
                         (),
-                        sorted(other_child.children, key=lambda n: n.frame),
+                        sorted(other_child.children, key=key),
                         new_node,
                     )
                 connect(parent, new_node)
@@ -339,8 +343,8 @@ class Graph:
 
         # First establish which nodes correspond to each other
         new_roots = _merge(
-            sorted(self.roots, key=lambda n: n.frame),
-            sorted(other.roots, key=lambda n: n.frame),
+            sorted(self.roots, key=key),
+            sorted(other.roots, key=key),
             None,
         )
 

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -23,10 +23,10 @@ def index_by(attr, objects):
 class Graph:
     """A possibly multi-rooted tree or graph from one input dataset."""
 
-    def __init__(self, roots):
+    def __init__(self, roots, node_ordering=False):
         assert roots is not None
         self.roots = roots
-        self.node_ordering = False
+        self.node_ordering = node_ordering
 
     def traverse(self, order="pre", attrs=None, visited=None):
         """Preorder traversal of all roots of this Graph.
@@ -38,6 +38,12 @@ class Graph:
 
         Only preorder traversal is currently supported.
         """
+        # Call node_order_traverse instead if node_ordering is True
+        if self.node_ordering:
+            yield from self.node_order_traverse(
+                order=order, attrs=attrs, visited=visited
+            )
+            return
         # share visited dict so that we visit each node at most once.
         if visited is None:
             visited = {}
@@ -186,8 +192,9 @@ class Graph:
             for old_child in old.children:
                 new.children.append(old_to_new[old_child])
 
-        graph = Graph([old_to_new[r] for r in self.roots])
-        graph.node_ordering = self.node_ordering
+        graph = Graph(
+            [old_to_new[r] for r in self.roots], node_ordering=self.node_ordering
+        )
         graph.enumerate_traverse()
 
         return graph
@@ -337,7 +344,7 @@ class Graph:
             None,
         )
 
-        graph = Graph(new_roots)
+        graph = Graph(new_roots, node_ordering=self.node_ordering)
         graph.enumerate_traverse()
 
         return graph

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -631,9 +631,7 @@ class GraphFrame:
         visited = set()
         for root in self.graph.roots:
             rewire(root, None, visited)
-        graph = Graph(new_roots)
-        if self.graph.node_ordering:
-            graph.node_ordering = True
+        graph = Graph(new_roots, node_ordering=self.graph.node_ordering)
         graph.enumerate_traverse()
 
         # reindex new dataframe with new nodes
@@ -1488,7 +1486,7 @@ class GraphFrame:
         tmp_df.set_index(df_index, inplace=True)
 
         # update _hatchet_nid in reindexed graph and groupby-aggregate dataframe
-        graph = Graph(new_roots)
+        graph = Graph(new_roots, node_ordering=self.graph.node_ordering)
         graph.enumerate_traverse()
 
         # put it all together

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -400,9 +400,7 @@ class CaliperNativeReader:
         self.df_nodes = pd.DataFrame(data=list(self.idx_to_node.values()))
 
         # create a graph object once all the nodes have been added
-        graph = Graph(list_roots)
-        if self.node_ordering:
-            graph.node_ordering = True
+        graph = Graph(list_roots, node_ordering=self.node_ordering)
         graph.enumerate_traverse()
 
         metadata = self.filename_or_caliperreader.globals

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -375,9 +375,8 @@ class CaliperReader:
         self.df_metrics = pd.concat([self.df_fixed_data, self.df_missing])
 
         # create a graph object once all the nodes have been added
-        graph = Graph(list_roots)
+        graph = Graph(list_roots, node_ordering=self.node_ordering)
         if self.node_ordering:
-            graph.node_ordering = True
             # we do not want to expose the "Node order" column to the user
             self.df_metrics = self.df_metrics.drop(columns="Node order")
         graph.enumerate_traverse()


### PR DESCRIPTION
This PR fixes some instances where `node_ordering` was not being set properly after creating a new Graph. Also, enables calling `node_order_traverse()` from `traverse()` if `node_ordering==True`.

Additionally, enable using `_hatchet_nid` as a sorting key for `graph.union()`, such that node ordered `GraphFrame.unify()` and `Thicket.unify()` works correctly.

If we wanted to make sure `node_ordering` is intentionally set every time `Graph()` is called, we could remove the default of `False` and make `node_ordering` a required argument. But then for non-caliper readers it wouldn't make sense to have to set `node_ordering`.