### PR TITLE
Update to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -16,7 +16,7 @@ jobs:
 
   build_wheels_linux_3:
     name: Build wheels for Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +37,7 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -58,7 +58,7 @@ jobs:
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
       - build_sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v4
@@ -83,7 +83,7 @@ jobs:
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
       - build_sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -16,7 +16,7 @@ jobs:
 
   build_wheels_linux_3:
     name: Build wheels for Linux
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +37,7 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -58,7 +58,7 @@ jobs:
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
       - build_sdist
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v4
@@ -83,7 +83,7 @@ jobs:
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
       - build_sdist
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -17,10 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: change ubuntu-24.04 back to ubuntu-latest when the following issue is resolved:
-        #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-24.04]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-22.04]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         hatchet-version: ["2022.2.0"]
 
     steps:

--- a/.github/workflows/pip-install-tester.yaml
+++ b/.github/workflows/pip-install-tester.yaml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
+        # TODO: change ubuntu-24.04 back to ubuntu-latest when the following issue is resolved:
         #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: [3.6, 3.7, 3.8, 3.9]
         hatchet-version: ["2022.2.0"]
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,9 +13,7 @@ jobs:
     strategy:
       matrix:
         # TODO: add macos-latest
-        # TODO: change ubuntu-20.04 back to ubuntu-latest when the following issue is resolved:
-        #       https://github.com/actions/setup-python/issues/162
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         # TODO: add pypy2, pypy3
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # TODO: add macos-latest
-        os: [ubuntu-24.04]
+        os: [ubuntu-22.04]
         # TODO: add pypy2, pypy3
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
@@ -79,13 +79,6 @@ jobs:
         cd $GITHUB_WORKSPACE
         echo -e "PWD:${PWD}"
         which cali-query
-
-#    - name: Build Timemory for Python 3.6
-#      if: ${{ matrix.python-version == 3.6 }}
-#      run: |
-#        python -m pip install --upgrade scikit-build
-#        # python -m pip install --upgrade --no-cache-dir --no-deps -v --pre timemory --install-option=--disable-{c,gotcha,tools}
-#        python -m pip install --upgrade --no-cache-dir --no-deps -v timemory==3.2.0.dev4 --install-option=--disable-{c,gotcha,tools}
 
     - name: Test Caliper and Timemory Support with pytest
       run: |


### PR DESCRIPTION
CI broken on develop since Ubuntu 20.04 runner deprecated.

```
Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```
