### PR TITLE
Update Examples to Use from_caliperreader by Default

### DIFF
--- a/docs/analysis_examples.rst
+++ b/docs/analysis_examples.rst
@@ -29,9 +29,14 @@ Read in a Caliper cali file
 ---------------------------
 
 `Caliper <http://software.llnl.gov/Caliper/>`_'s default raw performance data
-output is the `cali <http://llnl.github.io/Caliper/OutputFormats.html#cali>`_.
-The cali format can be read by ``cali-query``, which transforms the raw data into
-JSON format.
+output is the `cali <http://llnl.github.io/Caliper/OutputFormats.html#cali>`_ file.
+``from_caliperreader`` is the recommended reader for ``cali`` files.
+
+.. literalinclude:: examples/read/caliper_caliperreader_cali.py
+    :language: python
+
+Alternatively, the ``from_caliper`` reader can be used for Caliper files generated
+with Caliper version ``<=2.10``. This is useful if the user intends to use ``cali-query``.
 
 .. literalinclude:: examples/read/caliper_cali_query.py
     :language: python

--- a/docs/basic_tutorial.rst
+++ b/docs/basic_tutorial.rst
@@ -59,14 +59,14 @@ Introduction
 ------------
 
 You can read in a dataset into Hatchet for analysis by using one of several
-``from_`` static methods. For example, you can read in a Caliper JSON file as
+``from_`` static methods. For example, you can read in a Caliper file as
 follows:
 
 .. code-block:: console
 
   >>> import hatchet as ht
-  >>> caliper_file = 'lulesh-annotation-profile-1core.json'
-  >>> gf = ht.GraphFrame.from_caliper(caliper_file)
+  >>> caliper_file = 'lulesh-annotation-profile-1core.cali'
+  >>> gf = ht.GraphFrame.from_caliperreader(caliper_file)
   >>>
 
 At this point, your input file (profile) has been loaded into Hatchet's data


### PR DESCRIPTION
For `.cali` files, we prefer the usage of `from_caliperreader` over `from_caliper`. This currently isn't reflected in the docs.