### PR TITLE
Allows Hatchet to work with NumPy >= 2.0

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -373,10 +373,10 @@ class GraphFrame:
 
         return JsonReader(json_spec).read(**kwargs)
 
+    @staticmethod
     @deprecated(
         "Reading from/writing to HDF5 is deprecated and will be removed in a later version."
     )
-    @staticmethod
     def from_hdf(filename, **kwargs):
         try:
             # import this lazily to avoid circular dependencies

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -374,7 +374,9 @@ class GraphFrame:
 
         return JsonReader(json_spec).read(**kwargs)
 
-    @deprecated("Reading from/writing to HDF5 is deprecated and will be removed in a later version.")
+    @deprecated(
+        "Reading from/writing to HDF5 is deprecated and will be removed in a later version."
+    )
     @staticmethod
     def from_hdf(filename, **kwargs):
         try:
@@ -394,7 +396,9 @@ class GraphFrame:
                 )
             raise ve
 
-    @deprecated("Reading from/writing to HDF5 is deprecated and will be removed in a later version.")
+    @deprecated(
+        "Reading from/writing to HDF5 is deprecated and will be removed in a later version."
+    )
     def to_hdf(self, filename, key="hatchet_graphframe", **kwargs):
         try:
             # import this lazily to avoid circular dependencies

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -383,14 +383,15 @@ class GraphFrame:
 
             return HDF5Reader(filename).read(**kwargs)
         except ValueError as ve:
-            ve_msg = str(ve)
-            if ve_msg.startswith("numpy.dtype size changed") and _validate_numpy_version_for_hdf():
-                raise ValueError(
-                    "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
+            if _validate_numpy_version_for_hdf():
+                ve_msg = str(ve)
+                if ve_msg.startswith("numpy.dtype size changed"):
+                    raise ValueError(
+                        "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
+                    )
+                print(
+                    "The error below is not clearly caused by incompatibilities between the versions of NumPy, Pandas, and/or PyTables, but it may still be."
                 )
-            print(
-                "The error below is not clearly caused by incompatibilities between the versions of NumPy, Pandas, and/or PyTables, but it may still be."
-            )
             raise ve
 
     @deprecated("Reading from/writing to HDF5 is deprecated and will be removed in a later version.")
@@ -401,14 +402,15 @@ class GraphFrame:
 
             HDF5Writer(filename).write(self, key=key, **kwargs)
         except ValueError as ve:
-            ve_msg = str(ve)
-            if ve_msg.startswith("numpy.dtype size changed") and _validate_numpy_version_for_hdf():
-                raise ValueError(
-                    "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
+            if _validate_numpy_version_for_hdf():
+                ve_msg = str(ve)
+                if ve_msg.startswith("numpy.dtype size changed"):
+                    raise ValueError(
+                        "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
+                    )
+                print(
+                    "The error below is not clearly caused by incompatibilities between the versions of NumPy, Pandas, and/or PyTables, but it may still be."
                 )
-            print(
-                "The error below is not clearly caused by incompatibilities between the versions of NumPy, Pandas, and/or PyTables, but it may still be."
-            )
             raise ve
 
     def copy(self):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -8,7 +8,6 @@ import json
 import sys
 import traceback
 from collections import defaultdict
-from warnings import deprecated
 
 import multiprocess as mp
 import numpy as np
@@ -26,7 +25,7 @@ from .query import (
     parse_string_dialect,
 )
 from .util import _validate_numpy_version_for_hdf
-from .util.deprecated import deprecated_params
+from .util.deprecated import deprecated_params, deprecated
 from .util.dot import trees_to_dot
 
 try:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -25,6 +25,7 @@ from .query import (
     is_hatchet_query,
     parse_string_dialect,
 )
+from .util import _validate_numpy_version_for_hdf
 from .util.deprecated import deprecated_params
 from .util.dot import trees_to_dot
 
@@ -383,7 +384,7 @@ class GraphFrame:
             return HDF5Reader(filename).read(**kwargs)
         except ValueError as ve:
             ve_msg = str(ve)
-            if ve_msg.startswith("numpy.dtype size changed"):
+            if ve_msg.startswith("numpy.dtype size changed") and _validate_numpy_version_for_hdf():
                 raise ValueError(
                     "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
                 )
@@ -401,7 +402,7 @@ class GraphFrame:
             HDF5Writer(filename).write(self, key=key, **kwargs)
         except ValueError as ve:
             ve_msg = str(ve)
-            if ve_msg.startswith("numpy.dtype size changed"):
+            if ve_msg.startswith("numpy.dtype size changed") and _validate_numpy_version_for_hdf():
                 raise ValueError(
                     "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
                 )

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -8,6 +8,7 @@ import json
 import sys
 import traceback
 from collections import defaultdict
+from warnings import deprecated
 
 import multiprocess as mp
 import numpy as np
@@ -372,18 +373,42 @@ class GraphFrame:
 
         return JsonReader(json_spec).read(**kwargs)
 
+    @deprecated("Reading from/writing to HDF5 is deprecated and will be removed in a later version.")
     @staticmethod
     def from_hdf(filename, **kwargs):
-        # import this lazily to avoid circular dependencies
-        from .readers.hdf5_reader import HDF5Reader
+        try:
+            # import this lazily to avoid circular dependencies
+            from .readers.hdf5_reader import HDF5Reader
 
-        return HDF5Reader(filename).read(**kwargs)
+            return HDF5Reader(filename).read(**kwargs)
+        except ValueError as ve:
+            ve_msg = str(ve)
+            if ve_msg.startswith("numpy.dtype size changed"):
+                raise ValueError(
+                    "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
+                )
+            print(
+                "The error below is not clearly caused by incompatibilities between the versions of NumPy, Pandas, and/or PyTables, but it may still be."
+            )
+            raise ve
 
+    @deprecated("Reading from/writing to HDF5 is deprecated and will be removed in a later version.")
     def to_hdf(self, filename, key="hatchet_graphframe", **kwargs):
-        # import this lazily to avoid circular dependencies
-        from .writers.hdf5_writer import HDF5Writer
+        try:
+            # import this lazily to avoid circular dependencies
+            from .writers.hdf5_writer import HDF5Writer
 
-        HDF5Writer(filename).write(self, key=key, **kwargs)
+            HDF5Writer(filename).write(self, key=key, **kwargs)
+        except ValueError as ve:
+            ve_msg = str(ve)
+            if ve_msg.startswith("numpy.dtype size changed"):
+                raise ValueError(
+                    "There is an incompatibility between the versions NumPy, Pandas, and/or PyTables. This is usually a side effect of using NumPy >= 2.0 with PyTables < 3.10."
+                )
+            print(
+                "The error below is not clearly caused by incompatibilities between the versions of NumPy, Pandas, and/or PyTables, but it may still be."
+            )
+            raise ve
 
     def copy(self):
         """Return a partially shallow copy of the graphframe.

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -8,7 +8,6 @@
 from __future__ import division
 
 import os
-import sys
 
 import numpy as np
 import pandas as pd

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1126,7 +1126,7 @@ def test_inc_metric_only(mock_graph_inc_metric_only):
 
 @pytest.mark.skipif(
     _validate_numpy_version_for_hdf(),
-    reason="Cannot perform HDF operations for Python < 3.10 and NumPy >= 2.0"
+    reason="Cannot perform HDF operations for Python < 3.10 and NumPy >= 2.0",
 )
 def test_hdf_load_store(mock_graph_literal):
     if os.path.exists("test_gframe.hdf"):

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -8,17 +8,18 @@
 from __future__ import division
 
 import os
-
-import pytest
+import sys
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from hatchet import GraphFrame, QueryMatcher
-from hatchet.graphframe import InvalidFilter, EmptyFilter
 from hatchet.frame import Frame
 from hatchet.graph import Graph
+from hatchet.graphframe import EmptyFilter, InvalidFilter
 from hatchet.node import Node
+from hatchet.util import _validate_numpy_version_for_hdf
 from hatchet.version import __version__
 
 
@@ -1123,6 +1124,7 @@ def test_inc_metric_only(mock_graph_inc_metric_only):
     assert gf.exc_metrics == filt_gf.exc_metrics
 
 
+@pytest.mark.skipif(_validate_numpy_version_for_hdf(), reason="Cannot perform HDF operations for Python < 3.10 and NumPy >= 2.0")
 def test_hdf_load_store(mock_graph_literal):
     if os.path.exists("test_gframe.hdf"):
         os.remove("test_gframe.hdf")

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1124,7 +1124,10 @@ def test_inc_metric_only(mock_graph_inc_metric_only):
     assert gf.exc_metrics == filt_gf.exc_metrics
 
 
-@pytest.mark.skipif(_validate_numpy_version_for_hdf(), reason="Cannot perform HDF operations for Python < 3.10 and NumPy >= 2.0")
+@pytest.mark.skipif(
+    _validate_numpy_version_for_hdf(),
+    reason="Cannot perform HDF operations for Python < 3.10 and NumPy >= 2.0"
+)
 def test_hdf_load_store(mock_graph_literal):
     if os.path.exists("test_gframe.hdf"):
         os.remove("test_gframe.hdf")

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -3,27 +3,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pytest
-
 import re
 
 import numpy as np
+import pytest
 
 from hatchet import GraphFrame
 from hatchet.node import traversal_order
 from hatchet.query import (
-    Query,
-    ObjectQuery,
-    StringQuery,
-    parse_string_dialect,
-    QueryEngine,
-    InvalidQueryFilter,
-    InvalidQueryPath,
     CompoundQuery,
     ConjunctionQuery,
     DisjunctionQuery,
     ExclusiveDisjunctionQuery,
+    InvalidQueryFilter,
+    InvalidQueryPath,
     NegationQuery,
+    ObjectQuery,
+    Query,
+    QueryEngine,
+    StringQuery,
+    parse_string_dialect,
 )
 from hatchet.query.errors import MultiIndexModeMismatch
 
@@ -1092,7 +1091,7 @@ def test_apply_string_dialect(mock_graph_literal):
     query = StringQuery(path)
     assert engine.apply(query, gf.graph, gf.dataframe) == []
 
-    gf.dataframe["time"] = np.NaN
+    gf.dataframe["time"] = np.nan
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
     path = """MATCH ("*", p)
     WHERE p."time" IS NOT NAN"""
@@ -1101,14 +1100,14 @@ def test_apply_string_dialect(mock_graph_literal):
     assert engine.apply(query, gf.graph, gf.dataframe) == match
 
     gf.dataframe["time"] = 5.0
-    gf.dataframe.at[gf.graph.roots[0], "time"] = np.NaN
+    gf.dataframe.at[gf.graph.roots[0], "time"] = np.nan
     path = """MATCH ("*", p)
     WHERE p."time" IS NAN"""
     match = [gf.graph.roots[0]]
     query = StringQuery(path)
     assert engine.apply(query, gf.graph, gf.dataframe) == match
 
-    gf.dataframe["time"] = np.Inf
+    gf.dataframe["time"] = np.inf
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
     path = """MATCH ("*", p)
     WHERE p."time" IS NOT INF"""
@@ -1117,7 +1116,7 @@ def test_apply_string_dialect(mock_graph_literal):
     assert engine.apply(query, gf.graph, gf.dataframe) == match
 
     gf.dataframe["time"] = 5.0
-    gf.dataframe.at[gf.graph.roots[0], "time"] = np.Inf
+    gf.dataframe.at[gf.graph.roots[0], "time"] = np.inf
     path = """MATCH ("*", p)
     WHERE p."time" IS INF"""
     match = [gf.graph.roots[0]]

--- a/hatchet/tests/query_compat.py
+++ b/hatchet/tests/query_compat.py
@@ -3,24 +3,23 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pytest
-
 import numpy as np
+import pytest
 
 from hatchet import GraphFrame
 from hatchet.query import (
-    QueryMatcher,
+    AbstractQuery,
+    AndQuery,
+    CypherQuery,
+    IntersectionQuery,
     InvalidQueryFilter,
     InvalidQueryPath,
-    AbstractQuery,
     NaryQuery,
-    AndQuery,
     OrQuery,
-    XorQuery,
-    IntersectionQuery,
-    UnionQuery,
+    QueryMatcher,
     SymDifferenceQuery,
-    CypherQuery,
+    UnionQuery,
+    XorQuery,
     parse_cypher_query,
 )
 
@@ -500,7 +499,7 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert query.apply(gf) == []
 
-    gf.dataframe["time"] = np.NaN
+    gf.dataframe["time"] = np.nan
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
     path = """MATCH ("*", p)
     WHERE p."time" IS NOT NAN"""
@@ -509,14 +508,14 @@ def test_apply_cypher(mock_graph_literal):
     assert query.apply(gf) == match
 
     gf.dataframe["time"] = 5.0
-    gf.dataframe.at[gf.graph.roots[0], "time"] = np.NaN
+    gf.dataframe.at[gf.graph.roots[0], "time"] = np.nan
     path = """MATCH ("*", p)
     WHERE p."time" IS NAN"""
     match = [gf.graph.roots[0]]
     query = CypherQuery(path)
     assert query.apply(gf) == match
 
-    gf.dataframe["time"] = np.Inf
+    gf.dataframe["time"] = np.inf
     gf.dataframe.at[gf.graph.roots[0], "time"] = 5.0
     path = """MATCH ("*", p)
     WHERE p."time" IS NOT INF"""
@@ -525,7 +524,7 @@ def test_apply_cypher(mock_graph_literal):
     assert query.apply(gf) == match
 
     gf.dataframe["time"] = 5.0
-    gf.dataframe.at[gf.graph.roots[0], "time"] = np.Inf
+    gf.dataframe.at[gf.graph.roots[0], "time"] = np.inf
     path = """MATCH ("*", p)
     WHERE p."time" IS INF"""
     match = [gf.graph.roots[0]]

--- a/hatchet/util/__init__.py
+++ b/hatchet/util/__init__.py
@@ -2,3 +2,13 @@
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+
+import sys
+
+import numpy as np
+
+
+def _validate_numpy_version_for_hdf():
+    is_py_lt_3_10 = sys.version_info < (3, 10)
+    is_np_ge_2 = tuple(map(int, (np.__version__.split(".")))) >= (2, 0)
+    return is_py_lt_3_10 and is_np_ge_2

--- a/hatchet/util/deprecated.py
+++ b/hatchet/util/deprecated.py
@@ -6,7 +6,7 @@
 import functools
 
 try:
-    from warnings import deprecated # type: ignore
+    from warnings import deprecated  # type: ignore
 except ImportError:
     from warnings import warn
 

--- a/hatchet/util/deprecated.py
+++ b/hatchet/util/deprecated.py
@@ -5,6 +5,22 @@
 
 import functools
 
+try:
+    from warnings import deprecated # type: ignore
+except ImportError:
+    from warnings import warn
+
+    def deprecated(msg):
+        def deprecated_deco(f):
+            @functools.wraps(f)
+            def wrapper(*args, **kwargs):
+                warn(msg, DeprecationWarning)
+                return f(*args, **kwargs)
+
+            return wrapper
+
+        return deprecated_deco
+
 
 def deprecated_params(**old_to_new):
     def deco(f):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pydot
 pytest
 codecov
 pep8-naming
-numpy < 2.0.0
+numpy
 PyYAML
 cython
 multiprocess

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-from setuptools import setup
-from setuptools import Extension
 from codecs import open
 from os import path
+
+from setuptools import Extension, setup
 
 here = path.abspath(path.dirname(__file__))
 
@@ -57,7 +57,7 @@ for mname in mod_names:
         )
 
 if should_cythonize:
-    from Cython.Build import cythonize, build_ext
+    from Cython.Build import build_ext, cythonize
 
     ext_modules = cythonize(ext_modules)
     cmd_class.update({"build_ext": build_ext})
@@ -111,7 +111,7 @@ setup(
         "pydot",
         "PyYAML",
         "matplotlib",
-        "numpy < 2.0.0",
+        "numpy",
         "pandas",
         "textX < 3.0.0; python_version < '3.6'",
         "textX >= 3.0.0; python_version >= '3.6'",


### PR DESCRIPTION
Follow up to #140.

This PR knocks out the last few minor changes that needed to be made to support NumPy >= 2.0. It also changes `requirements.txt` and `setup.py` to remove the strict version limit of < 2.0.