### PR TITLE
Remove Extra Aggregation in Timeseries

### DIFF
--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -90,11 +90,7 @@ class CaliperNativeReader:
 
         # Aggregate on nid if timeseries data
         if self.timeseries_level in df_metrics:
-            df_new = (
-                df_metrics.groupby("nid")
-                .aggregate("mean")
-                .reset_index()
-            )
+            df_new = df_metrics.groupby("nid").aggregate("mean").reset_index()
         # Don't agg multi rank
         elif "mpi.rank" in df_metrics:
             df_new = df_metrics

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -89,9 +89,9 @@ class CaliperNativeReader:
         df_metrics = pd.DataFrame.from_dict(data=metrics)
 
         # Aggregate on nid if timeseries data
-        if "loop.start_iteration" in df_metrics:
+        if self.timeseries_level in df_metrics:
             df_new = (
-                df_metrics.groupby(["nid", "loop.start_iteration"])
+                df_metrics.groupby("nid")
                 .aggregate("mean")
                 .reset_index()
             )

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -921,7 +921,7 @@ def test_graphframe_timeseries_lulesh_from_file(caliper_timeseries_cali):
         assert tcol in gf.dataframe.columns
 
     # verify some values are as expected
-    assert np.isnan(gf.dataframe["alloc.region.highwatermark"].iloc[0])
+    assert gf.dataframe["alloc.region.highwatermark"].iloc[0] == 25824351.0
     assert gf.dataframe["alloc.region.highwatermark"].iloc[1] == 63732320.0
-    assert gf2.dataframe["loop.start_iteration"].iloc[0] == 4.0
-    assert gf2.dataframe["alloc.region.highwatermark"].iloc[0] == 63732320.0
+    assert np.isnan(gf2.dataframe["loop.start_iteration"].iloc[0])
+    assert np.isnan(gf2.dataframe["alloc.region.highwatermark"].iloc[0])


### PR DESCRIPTION
https://github.com/LLNL/hatchet/pull/157 added `mean`, which correctly fixes aggregation for timeseries records, but added an extra aggregation level `loop.start_iteration`, which should not be aggregated on in order to correctly unify multi-iteration timeseries data.