### PR TITLE
bump for major release 2025.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 2025.1.0 (2025-07-03)
+
+Version `2023.1.0` is a major release.
+
+### Notable Changes
+* Display more than 2 metrics on the tree visualization (#165)
+* Allows Hatchet to work with NumPy >= 2.0 (#163)
+* Remove Extra Aggregation in Timeseries (#164)
+* Aggregate on String Attributes (#158)
+* Disable Aggregation for non-timeseries Profiles (#157)
+
+### Bugfixes
+* Fix Node Ordering Setting (#154)
+* Fix sum(nan) == 0 in caliper native reader (#166)
+
+### Internal Updates
+* Skip HDF Test if Package not Available (#156)
+* Update examples to use from_caliperreader by default, instead of from_caliper (#160)
+* Update to Ubuntu 22.04 (#159)
+
 # 2024.1.1 (2024-04-09)
 
 Version `2024.1.1` is a minor release on the `2024.1` series.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,13 +25,13 @@ import pkg_resources
 # -- Project information -----------------------------------------------------
 
 project = "hatchet"
-copyright = "2017-2023, Lawrence Livermore National Security, LLC"
+copyright = "2017-2025, Lawrence Livermore National Security, LLC"
 author = "LLNL Developers"
 
 # The short X.Y version
-version = "2024.1.1"
+version = "2025.1.0"
 # The full version, including alpha/beta/rc tags
-release = "2024.1.1"
+release = "2025.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/hatchet.readers.rst
+++ b/docs/source/hatchet.readers.rst
@@ -60,6 +60,14 @@ hatchet.readers.hpctoolkit\_reader module
    :undoc-members:
    :show-inheritance:
 
+hatchet.readers.hpctoolkit\_reader\_latest module
+-------------------------------------------------
+
+.. automodule:: hatchet.readers.hpctoolkit_reader_latest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 hatchet.readers.json\_reader module
 -----------------------------------
 

--- a/docs/source/hatchet.rst
+++ b/docs/source/hatchet.rst
@@ -18,14 +18,6 @@ Subpackages
 Submodules
 ----------
 
-hatchet.caliper\_json module
-----------------------------
-
-.. automodule:: hatchet.caliper_json
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 hatchet.frame module
 --------------------
 


### PR DESCRIPTION
- update sphinx-apidoc
- bump version
- increase copyright year to 2025
- update CHANGELOG