### PR TITLE
Disables attestations in gh-action-pypi-publish to avoid errors from PyPI

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -76,6 +76,8 @@ jobs:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+          attestations: false
+          verbose: true
 
   upload_to_pypi:
     needs:
@@ -100,5 +102,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          # Uncomment the line below if you want to upload to PyPI
-          # repository_url: https://test.pypi.org/legacy/
+          attestations: false
+          verbose: true


### PR DESCRIPTION
This PR *should* resolve an issue @slabasan was having the the PyPI package pusher in CI.

Apparently, since we last ran this CI, PyPA has added a trusted publishing and attestation mechanism. However, it appears that using attestations (which is now default in the `gh-action-pypi-publish` action) without also using trusted publishing (i.e., publishing without PyPI API tokens) will cause PyPI to respond to package upload requests with an HTTP 400 error.

So, to prevent that, this PR simply adds an `attestations: false` setting to the use of the `gh-action-pypi-publish` action. This PR also adds `verbose: true` to the action to help us get more useful error messages in the future.