### PR TITLE
Add support for reading rocm kernels from rocm-activity-profile

### DIFF
--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -324,7 +324,7 @@ class CaliperNativeReader:
                             elif "hipMemcpy" in record["rocm.api"]:
                                 node_label = record["rocm.activity"]
                                 # Theres going to be an extra record at the end that we must remove
-                                pop_item = record[ctx].pop()
+                                record[ctx].pop()
                                 node_callpath = tuple(record[ctx] + [node_label])
                                 parent_callpath = node_callpath[:-1]
                                 node_type = "memcpy"

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -321,11 +321,15 @@ class CaliperNativeReader:
                                 node_callpath = tuple(record[ctx] + [node_label])
                                 parent_callpath = node_callpath[:-1]
                                 node_type = "kernel"
-                            else:
+                            elif "hipMemcpy" in record["rocm.api"]:
                                 node_label = record["rocm.activity"]
+                                # Theres going to be an extra record at the end that we must remove
+                                pop_item = record[ctx].pop()
                                 node_callpath = tuple(record[ctx] + [node_label])
                                 parent_callpath = node_callpath[:-1]
-                                node_type = "other"
+                                node_type = "memcpy"
+                            else:
+                                Exception("Haven't seen this activity kind yet")
                         # Sampling
                         elif "module#cali.sampler.pc" in record:
                             node_label = record["source.function#cali.sampler.pc"]

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -167,6 +167,14 @@ class CaliperNativeReader:
                             elif record["cupti.activity.kind"] == "memcpy":
                                 node_label = record["cupti.activity.kind"]
                                 node_callpath = tuple(record[ctx] + [node_label])
+                        # rocm records
+                        elif "rocm.activity" in record:
+                            if record["rocm.activity"] == "KernelExecution":
+                                node_label = record["rocm.kernel.name"]
+                                node_callpath = tuple(record[ctx] + [node_label])
+                            else:
+                                node_label = record["rocm.activity"]
+                                node_callpath = tuple(record[ctx] + [node_label])
                         # Sampling
                         elif "module#cali.sampler.pc" in record:
                             node_label = record["source.function#cali.sampler.pc"]
@@ -306,6 +314,18 @@ class CaliperNativeReader:
                                 node_type = "memcpy"
                             else:
                                 Exception("Haven't seen this activity kind yet")
+                        # rocm records
+                        elif "rocm.activity" in record:
+                            if record["rocm.activity"] == "KernelExecution":
+                                node_label = record["rocm.kernel.name"]
+                                node_callpath = tuple(record[ctx] + [node_label])
+                                parent_callpath = node_callpath[:-1]
+                                node_type = "kernel"
+                            else:
+                                node_label = record["rocm.activity"]
+                                node_callpath = tuple(record[ctx] + [node_label])
+                                parent_callpath = node_callpath[:-1]
+                                node_type = "other"
                         # Sampling
                         elif "module#cali.sampler.pc" in record:
                             node_label = record["source.function#cali.sampler.pc"]
@@ -453,7 +473,7 @@ class CaliperNativeReader:
             # add missing intermediate nodes to the df_fixed_data dataframe
             if "mpi.rank" in df_fixed_data.columns:
                 num_ranks = metrics["mpi.rank"].max() + 1
-                rank_list = range(0, num_ranks)
+                rank_list = range(0, int(num_ranks))
 
             # create a standard dict to be used for filling all missing rows
             default_metric_dict = {}


### PR DESCRIPTION
Support is required in the reader to add rocm kernels from Caliper files generated from `rocm-activity-profile` runs with roctx service. This matches the structure of how we read `cuda-activity-profile` files with nvtx. Also fix a bug when num_ranks is not an int

before
<img width="448" height="466" alt="image" src="https://github.com/user-attachments/assets/6d579e9d-92ff-44ca-a138-985dcb5a540a" />

after
<img width="448" height="466" alt="image" src="https://github.com/user-attachments/assets/347ba730-00a8-44e1-8b82-3e7ce8f10470" />
