### PR TITLE
pin pandas version to less than 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-pandas
+pandas<3
 pydot
 pytest
 codecov

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "PyYAML",
         "matplotlib",
         "numpy",
-        "pandas",
+        "pandas<3",
         "textX < 3.0.0; python_version < '3.6'",
         "textX >= 3.0.0; python_version >= '3.6'",
         "multiprocess",


### PR DESCRIPTION
temporarily require pandas version to be less than pandas3