### PR TITLE
Fix reading `rocm-activity-profile` for rocm>7 format

### DIFF
--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -331,7 +331,6 @@ class CaliperNativeReader:
                             elif "hipMemcpy" in record["rocm.api"]:
                                 node_label = record["rocm.activity"]
                                 # Theres going to be an extra record at the end that we must remove
-                                #print(record[ctx])
                                 if len(record[ctx]) > 0:
                                     record[ctx].pop()
                                 node_callpath = tuple(record[ctx] + [node_label])
@@ -346,7 +345,6 @@ class CaliperNativeReader:
                             parent_callpath = node_callpath[:-1]
                             node_type = "function"
                         else:
-                            #print(record[ctx])
                             if len(record[ctx]) > 0:
                                 node_label = record[ctx][-1]
                                 node_callpath = tuple(record[ctx])

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -172,7 +172,7 @@ class CaliperNativeReader:
                                 node_callpath = tuple(record[ctx] + [node_label])
                         # rocm records
                         elif "rocm.activity" in record:
-                            if record["rocm.activity"] == "KernelExecution":
+                            if record["rocm.activity"] == "KERNEL_DISPATCH_COMPLETE":
                                 node_label = record["rocm.kernel.name"]
                                 node_callpath = tuple(record[ctx] + [node_label])
                             else:
@@ -184,8 +184,12 @@ class CaliperNativeReader:
                             node_callpath = tuple(record[ctx])[:-1] + (node_label,)
                             sampling = True
                         else:
-                            node_label = record[ctx][-1]
-                            node_callpath = tuple(record[ctx])
+                            if len(record[ctx]) > 0:
+                                node_label = record[ctx][-1]
+                                node_callpath = tuple(record[ctx])
+                            else:
+                                node_label = "unknown_context"
+                                node_callpath = tuple("unknown_context")
                     else:
                         node_label = record[ctx]
                         node_callpath = tuple([record[ctx]])
@@ -319,7 +323,7 @@ class CaliperNativeReader:
                                 Exception("Haven't seen this activity kind yet")
                         # rocm records
                         elif "rocm.activity" in record:
-                            if record["rocm.activity"] == "KernelExecution":
+                            if record["rocm.activity"] == "KERNEL_DISPATCH_COMPLETE":
                                 node_label = record["rocm.kernel.name"]
                                 node_callpath = tuple(record[ctx] + [node_label])
                                 parent_callpath = node_callpath[:-1]
@@ -327,7 +331,9 @@ class CaliperNativeReader:
                             elif "hipMemcpy" in record["rocm.api"]:
                                 node_label = record["rocm.activity"]
                                 # Theres going to be an extra record at the end that we must remove
-                                record[ctx].pop()
+                                #print(record[ctx])
+                                if len(record[ctx]) > 0:
+                                    record[ctx].pop()
                                 node_callpath = tuple(record[ctx] + [node_label])
                                 parent_callpath = node_callpath[:-1]
                                 node_type = "memcpy"
@@ -340,10 +346,17 @@ class CaliperNativeReader:
                             parent_callpath = node_callpath[:-1]
                             node_type = "function"
                         else:
-                            node_label = record[ctx][-1]
-                            node_callpath = tuple(record[ctx])
-                            parent_callpath = node_callpath[:-1]
-                            node_type = "function"
+                            #print(record[ctx])
+                            if len(record[ctx]) > 0:
+                                node_label = record[ctx][-1]
+                                node_callpath = tuple(record[ctx])
+                                parent_callpath = node_callpath[:-1]
+                                node_type = "function"
+                            else:
+                                node_label = "unknown_context"
+                                node_callpath = tuple("unknown_context")
+                                parent_callpath = tuple("")
+                                node_type = "function"
 
                         hnode = self.callpath_to_node.get(node_callpath)
 


### PR DESCRIPTION
Fixes an error when reading `rocm-activity-profile` files, of the form:

```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
Cell In[6], line 3
      1 tks = []
      2 for f in glob(dir_of_cali_files, recursive=True):
----> 3     tk_roofline = tt.Thicket.from_caliperreader(f)
      5     # Fix for duplicate cali idx
      6     tk_roofline.dataframe = tk_roofline.dataframe[tk_roofline.dataframe["time (gpu)"] != 0].reset_index(level="rank", drop=True)

File /usr/workspace/mckinsey/data-driven/venv/lib/python3.11/site-packages/thicket/thicket.py:459, in Thicket.from_caliperreader(filename_or_caliperreader, intersection, fill_perfdata, disable_tqdm, node_ordering, **kwargs)
    440 @staticmethod
    441 def from_caliperreader(
    442     filename_or_caliperreader,
   (...)    447     **kwargs,
    448 ):
    449     """Helper function to read one caliper file.
    450 
    451     Arguments:
   (...)    457         node_ordering (bool): whether to apply node ordering to the graph
    458     """
--> 459     return Thicket.reader_dispatch(
    460         GraphFrame.from_caliperreader,
    461         intersection,
    462         fill_perfdata,
    463         disable_tqdm,
    464         filename_or_caliperreader,
    465         node_ordering=node_ordering,
    466         **kwargs,
    467     )

File /usr/workspace/mckinsey/data-driven/venv/lib/python3.11/site-packages/thicket/thicket.py:609, in Thicket.reader_dispatch(func, intersection, fill_perfdata, disable_tqdm, *args, **kwargs)
    607 # if single file
    608 elif os.path.isfile(obj):
--> 609     return Thicket.thicketize_graphframe(func(*args, **kwargs), args[0])
    611 # Perform ensembling operation
    612 calltree = "union"

File /usr/workspace/mckinsey/data-driven/venv/lib/python3.11/site-packages/hatchet/graphframe.py:222, in GraphFrame.from_caliperreader(filename_or_caliperreader, native, string_attributes, node_ordering)
    217 # import this lazily to avoid circular dependencies
    218 from .readers.caliper_native_reader import CaliperNativeReader
    220 return CaliperNativeReader(
    221     filename_or_caliperreader, native, string_attributes, node_ordering
--> 222 ).read()

File /usr/workspace/mckinsey/data-driven/venv/lib/python3.11/site-packages/hatchet/readers/caliper_native_reader.py:470, in CaliperNativeReader.read(self)
    467         self.filename_or_caliperreader.read(cali_file)
    469 with self.timer.phase("graph construction"):
--> 470     list_roots = self.create_graph()
    471 self.df_nodes = pd.DataFrame(data=list(self.idx_to_node.values()))
    473 # create a graph object once all the nodes have been added

File /usr/workspace/mckinsey/data-driven/venv/lib/python3.11/site-packages/hatchet/readers/caliper_native_reader.py:348, in CaliperNativeReader.create_graph(self, ctx)
    345     parent_callpath = node_callpath[:-1]
    346     node_type = "function"
--> 348 hnode = self.callpath_to_node.get(node_callpath)
    350 if not hnode:
    351     # set the _hatchet_nid by the node order column if it exists, else -1
    352     if (
    353         self.node_ordering
    354         and "min#min#aggregate.slot" in record
    355     ):

UnboundLocalError: cannot access local variable 'node_callpath' where it is not associated with a value
```